### PR TITLE
release: v0.8.5 - Bulk Configuration, Wildcard Pattern Matching, Stack Trace Columns & Hierarchy Safeguards

### DIFF
--- a/doc/logger/README.md
+++ b/doc/logger/README.md
@@ -157,6 +157,8 @@ final snapshot = Logger.exportConfig();
 Logger.importConfig(snapshot);
 ```
 
+For a comprehensive guide on custom serialization and dynamic configuration updates across background workers, see the [Isolate Coordination Guide](isolates.md).
+
 ### Performance Optimization
 
 - Use `logger.freezeInheritance()` for hot paths (e.g., tight loops) where configuration is guaranteed static. This reduces lookup latency to a simple O(1) cache access.
@@ -189,4 +191,5 @@ FlutterError.onError = (final details) {
 
 - [Design Philosophy](philosophy.md) - Core principles and rationale
 - [Architecture](architecture.md) - Internal implementation details
+- [Isolate Coordination](isolates.md) - Multi-isolate configuration syncing
 - [Roadmap](roadmap.md) - Planned improvements and known issues

--- a/doc/logger/README.md
+++ b/doc/logger/README.md
@@ -91,7 +91,8 @@ The construction of `LogEntry` objects is an automated internal concern. The `Lo
 ### Configuration
 - `Logger.configure(name, ...)` - Set configuration for a logger and its descendants
 - `Logger.configureMultiple(configurations)` - Configure multiple loggers at once using a map of logger names to `LoggerConfig` configurations (supports single-pass cache invalidation and atomic input validation)
-- Parameters for `configure`: `enabled`, `logLevel`, `includeFileLineInHeader`, `stackMethodCount`, `timestamp`, `stackTraceParser`, `handlers`, `autoSinkBuffer`
+- `Logger.configurePattern(pattern, ...)` - Set configuration for loggers matching a wildcard pattern (e.g., `app.services.*` or `*.database`). Evaluation occurs dynamically during hierarchy resolution, and newer pattern rules take precedence over older ones.
+- Parameters for `configure`, `configureMultiple`, and `configurePattern`: `enabled`, `logLevel`, `includeFileLineInHeader`, `stackMethodCount`, `timestamp`, `stackTraceParser`, `handlers`, `autoSinkBuffer`
 - Changes propagate dynamically to descendants unless explicitly overridden
 
 ### Logging Methods

--- a/doc/logger/README.md
+++ b/doc/logger/README.md
@@ -90,7 +90,8 @@ The construction of `LogEntry` objects is an automated internal concern. The `Lo
 
 ### Configuration
 - `Logger.configure(name, ...)` - Set configuration for a logger and its descendants
-- Parameters: `enabled`, `logLevel`, `includeFileLineInHeader`, `stackMethodCount`, `timestamp`, `stackTraceParser`, `handlers`, `autoSinkBuffer`
+- `Logger.configureMultiple(configurations)` - Configure multiple loggers at once using a map of logger names to `LoggerConfig` configurations (supports single-pass cache invalidation and atomic input validation)
+- Parameters for `configure`: `enabled`, `logLevel`, `includeFileLineInHeader`, `stackMethodCount`, `timestamp`, `stackTraceParser`, `handlers`, `autoSinkBuffer`
 - Changes propagate dynamically to descendants unless explicitly overridden
 
 ### Logging Methods

--- a/doc/logger/architecture.md
+++ b/doc/logger/architecture.md
@@ -333,6 +333,26 @@ void main() {
 
 This keeps `logd` compatible with pure Dart environments (VM, CLI, server, web) without SDK compilation blocks.
 
+## Wildcard Pattern Matching
+
+**Location**: `Logger._patternRules` and `Logger.configurePattern` in [`logger.dart`](../../packages/logd/lib/src/logger/logger.dart)
+
+In addition to hierarchy-based configuration inheritance, `logd` allows configuring loggers dynamically via glob-style wildcard patterns.
+
+**Matching Mechanics**:
+- `*` is compiled to `.*` (matches zero or more characters)
+- `?` is compiled to `.` (matches a single character)
+- Special regex characters are automatically escaped to prevent regex injection.
+- Case-insensitivity is enforced by compiling with `caseSensitive: false`.
+
+**Precedence Rules**:
+1. **Explicit Configuration**: A logger explicitly configured via `Logger.configure()` or `Logger.configureMultiple()` always takes precedence.
+2. **Wildcard Patterns (LIFO Order)**: If no explicit configuration matches, the resolver evaluates `_patternRules` in LIFO order (the latest registered pattern has the highest precedence).
+3. **Hierarchy Inheritance**: If no pattern matches, the resolver falls back to traversing up the logger's namespace ancestors to find the nearest configured parent.
+
+**Cache Invalidation**:
+Registering a pattern rule via `configurePattern` invalidates the entire cache (`LoggerCache.clear()`), as pattern rules can potentially match any logger in the tree.
+
 ## Freezing Inheritance
 
 **Location**: `Logger.freezeInheritance()` in [`logger.dart`](../../packages/logd/lib/src/logger/logger.dart)

--- a/doc/logger/architecture.md
+++ b/doc/logger/architecture.md
@@ -73,9 +73,10 @@ The `LoggerCache` maintains the derived state of the system using a versioned-in
 - When a parent logger is reconfigured, its version increments
 - Descendant loggers track their parent's version; if a mismatch is detected during a log call, the cache is invalidated and re-resolved lazily
 - Cache check: `cached.version == config.version`
+- **Batched Invalidation**: During bulk configuration updates via `Logger.configureMultiple()`, `LoggerCache.invalidateMultiple()` sweeps and invalidates all changed loggers and their descendants in a single pass to eliminate redundant cache eviction passes.
 
-**Deep Equality Optimization** (see `Logger.configure()`):
-- `Logger.configure` uses `operator ==` on all configuration components
+**Deep Equality Optimization** (see `Logger.configure()` / `Logger.configureMultiple()`):
+- `Logger.configure` and `Logger.configureMultiple` use `operator ==` on all configuration components
 - Collections use `mapEquals` and `listEquals` for deep comparison
 - If the provided configuration is value-identical to the existing one, the version is **not** incremented
 - Descendant caches remain valid, avoiding expensive invalidation

--- a/doc/logger/isolates.md
+++ b/doc/logger/isolates.md
@@ -1,0 +1,192 @@
+# Cross-Isolate Logger Coordination Guide
+
+In Dart, memory is not shared between isolates; each isolate has its own independent heap, global state, and static variables. Consequently, **`logd` logger configurations are isolate-local by default**. 
+
+If you configure a logger (e.g., setting its log level or adding custom sinks) in the main isolate, these settings **will not** propagate automatically to background worker isolates.
+
+To solve this, `logd` provides a robust, built-in serialization and transport layer. This guide details how to synchronize logger configurations across isolates, register custom components, and dynamically coordinate settings.
+
+---
+
+## 1. Basic Isolate Transport
+
+`logd` supports exporting the entire configuration tree from one isolate and importing it into another using JSON-compatible maps:
+
+```dart
+// 1. In the Main Isolate:
+// Export a snapshot of the current configurations (including pattern rules)
+final Map<String, dynamic> configSnapshot = Logger.exportConfig();
+
+// Pass `configSnapshot` as part of the initial message to the worker isolate.
+Isolate.spawn(workerEntryPoint, configSnapshot);
+```
+
+```dart
+// 2. In the Worker Isolate:
+void workerEntryPoint(Map<String, dynamic> configSnapshot) {
+  // Import the configurations in the background isolate
+  Logger.importConfig(configSnapshot);
+
+  // Now, the worker's loggers match the main isolate's configurations exactly
+  Logger.get('app.service').info('Worker initialized and configured!');
+}
+```
+
+---
+
+## 2. Syncing Custom Components (`LoggerSerializationRegistry`)
+
+When configurations are exported and imported, `logd` serializes the logging pipeline components (Sinks, Formatters, Filters, Decorators, and Engines) into JSON specs.
+
+Out of the box, `logd` automatically registers all built-in components (e.g., `ConsoleSink`, `FileSink`, `PlainFormatter`, `BoxDecorator`, `LevelFilter`, etc.). If your loggers use custom implementations of these components, you **must** register serializer/deserializer specs in both the main and worker isolates before exporting/importing configuration.
+
+### Custom Component Registration Example
+
+```dart
+import 'package:logd/logd.dart';
+
+// A custom log sink that forwards entries to a remote telemetry API
+class TelemetrySink extends LogSink<LogDocument> {
+  final String apiEndpoint;
+
+  const TelemetrySink({required this.apiEndpoint});
+
+  @override
+  Future<void> output(
+    LogDocument document,
+    LogEntry entry,
+    LogLevel level,
+    LogPipelineFactory factory,
+  ) async {
+    // Custom shipping logic...
+  }
+}
+
+// Register the custom TelemetrySink for cross-isolate serialization
+void registerCustomComponents() {
+  LoggerSerializationRegistry.registerSink<TelemetrySink>(
+    type: 'TelemetrySink',
+    fromJson: (final json) => TelemetrySink(
+      apiEndpoint: json['apiEndpoint'] as String,
+    ),
+    toJson: (final val) => <String, dynamic>{
+      'apiEndpoint': val.apiEndpoint,
+    },
+  );
+}
+```
+
+> [!IMPORTANT]
+> Call `registerCustomComponents()` at the very beginning of the program in **both** the spawning (main) and spawned (worker) isolates.
+
+---
+
+## 3. Dynamic Configuration Synchronization
+
+In long-running applications, logger configurations might change dynamically (e.g., when a user turns on debug logging via an admin dashboard). You can push these updates from the main isolate to worker isolates over a `SendPort`.
+
+### Complete Coordination Example
+
+Here is a copy-pasteable, end-to-end example demonstrating launching a worker, initializing its configuration, and sending dynamic level updates during runtime:
+
+```dart
+import 'dart:async';
+import 'dart:isolate';
+import 'package:logd/logd.dart';
+
+/// Message contract to pass configuration snapshots and updates
+class IsolateCommand {
+  final String action;
+  final Map<String, dynamic> payload;
+
+  const IsolateCommand({required this.action, required this.payload});
+}
+
+void main() async {
+  // 1. Configure the main isolate loggers
+  Logger.configure('app', logLevel: LogLevel.info);
+  
+  final mainLogger = Logger.get('app.main');
+  mainLogger.info('Main isolate starting worker...');
+
+  // 2. Setup ports for communication
+  final receivePort = ReceivePort();
+  
+  // Export initial config tree
+  final initialConfig = Logger.exportConfig();
+  
+  // Spawn the worker and pass the send port & initial config
+  final workerIsolate = await Isolate.spawn(
+    workerEntryPoint,
+    [receivePort.sendPort, initialConfig],
+  );
+
+  // Wait for the worker to send its Command Port
+  final completer = Completer<SendPort>();
+  receivePort.listen((final message) {
+    if (message is SendPort) {
+      completer.complete(message);
+    } else {
+      mainLogger.info('Received from worker: $message');
+    }
+  });
+
+  final workerCommandPort = await completer.future;
+
+  // 3. Simulate dynamic config updates in the Main Isolate
+  await Future.delayed(const Duration(seconds: 1));
+  mainLogger.info('Main Isolate: Raising logging level of "app" to warning...');
+  
+  // Update configuration locally
+  Logger.configure('app', logLevel: LogLevel.warning);
+  
+  // Send the updated config tree to the worker isolate
+  workerCommandPort.send(IsolateCommand(
+    action: 'update_config',
+    payload: Logger.exportConfig(),
+  ));
+
+  // Clean up after work is done
+  await Future.delayed(const Duration(seconds: 1));
+  workerIsolate.kill(priority: Isolate.beforeNextEvent);
+  receivePort.close();
+}
+
+/// Entry point for the worker isolate
+void workerEntryPoint(List<dynamic> initArgs) {
+  final SendPort mainSendPort = initArgs[0];
+  final Map<String, dynamic> initialConfig = initArgs[1];
+
+  // 1. Initialize logd with inherited config from Main Isolate
+  Logger.importConfig(initialConfig);
+  final workerLogger = Logger.get('app.worker');
+  
+  workerLogger.info('Worker: Initialized (this message will print)');
+
+  // 2. Setup a command port to receive dynamic config updates
+  final commandPort = ReceivePort();
+  mainSendPort.send(commandPort.sendPort);
+
+  commandPort.listen((final message) {
+    if (message is IsolateCommand && message.action == 'update_config') {
+      // Apply the updated config snapshot dynamically
+      Logger.importConfig(message.payload);
+      
+      // Let main isolate know the update is applied
+      mainSendPort.send('Worker: Applied config update.');
+      
+      // Test the new config. (If level was raised to warning, this info log won't print)
+      workerLogger.info('Worker: This should not print if level is warning');
+      workerLogger.warning('Worker: This warning WILL print!');
+    }
+  });
+}
+```
+
+---
+
+## 4. Best Practices
+
+* **Batch Updates**: Only send updates when configuration changes occur (avoid querying `exportConfig()` in tight loops).
+* **Resetting Before Import**: While `Logger.importConfig` overwrites configurations in-place, it is best practice to run `Logger.reset()` globally in the worker before importing if you want to ensure a clean, absolute state synchronization.
+* **Avoid Nested Isolate Sinks**: If your background isolate needs to write logs, it is often more performant to send logs back to the main isolate via `IsolateSink` rather than performing expensive I/O operations (like file writes) concurrently from multiple isolates.

--- a/doc/logger/philosophy.md
+++ b/doc/logger/philosophy.md
@@ -54,6 +54,7 @@ For hot-paths where even the overhead of checking a version number is too high, 
 - **Safety Safeguards**:
   - **Implicit Node Warning**: If `freezeInheritance` is called on a "ghost node" (a logger created via `Logger.get()` that was never explicitly configured), a warning is logged via `InternalLogger` to alert the developer that they may be freezing unresolved default values.
   - **Promotion Warning**: If `Logger.configure()` is called on a logger for a property that is currently frozen, the property is promoted to explicit, and a warning is emitted to alert the developer that they are erasing the frozen status (suggesting `unfreezeInheritance()` first if they wanted dynamic propagation instead).
+  - **Hierarchy Depth Warning**: If a logger is retrieved with a hierarchy depth exceeding a safety threshold (defaulting to 10), a warning is logged on first access to prevent potential performance issues or stack overflows. This safety limit is configurable via `Logger.maxHierarchyDepth`.
 
 **Rationale**: In performance-critical paths (e.g., hot event loops, high-throughput message handlers), every microsecond matters. Freezing allows developers to opt into zero-overhead logging, while diagnostics warnings and unfreezing tools keep the configuration lifecycle clean and manageable.
 

--- a/doc/logger/philosophy.md
+++ b/doc/logger/philosophy.md
@@ -180,7 +180,7 @@ Key APIs are marked `@internal` to restrict usage to the `logd` package:
 - Maintain a clean, predictable API surface
 
 **Public API**: Users interact only with:
-- `Logger.get()` / `Logger.configure()`
+- `Logger.get()` / `Logger.configure()` / `Logger.configureMultiple()`
 - `logger.trace()` / `logger.debug()` / `logger.info()` / `logger.warning()` / `logger.error()`
 - `logger.traceBuffer` / `logger.debugBuffer` / etc.
 
@@ -191,7 +191,7 @@ To prevent race conditions and ensure predictable behavior, resolved configurati
 ### Implementation
 - `_ResolvedConfig` fields are `final`
 - Collections are wrapped in `Map.unmodifiable()` and `List.unmodifiable()`
-- Modification requires calling `Logger.configure()`, which creates a new resolved config
+- Modification requires calling `Logger.configure()` or `Logger.configureMultiple()`, which creates a new resolved config
 
 **Rationale**: Immutability eliminates entire classes of bugs:
 - No accidental mutation of shared state

--- a/doc/logger/philosophy.md
+++ b/doc/logger/philosophy.md
@@ -54,7 +54,7 @@ For hot-paths where even the overhead of checking a version number is too high, 
 - **Safety Safeguards**:
   - **Implicit Node Warning**: If `freezeInheritance` is called on a "ghost node" (a logger created via `Logger.get()` that was never explicitly configured), a warning is logged via `InternalLogger` to alert the developer that they may be freezing unresolved default values.
   - **Promotion Warning**: If `Logger.configure()` is called on a logger for a property that is currently frozen, the property is promoted to explicit, and a warning is emitted to alert the developer that they are erasing the frozen status (suggesting `unfreezeInheritance()` first if they wanted dynamic propagation instead).
-  - **Hierarchy Depth Warning**: If a logger is retrieved with a hierarchy depth exceeding a safety threshold (defaulting to 10), a warning is logged on first access to prevent potential performance issues or stack overflows. This safety limit is configurable via `Logger.maxHierarchyDepth`.
+  - **Hierarchy Depth Warning**: If a logger is retrieved with a hierarchy depth exceeding a safety threshold (defaulting to 10), a warning is logged on first access to prevent potential performance issues or stack overflows. This safety limit is configurable via `Logger.maxHierarchyDepth`. This can be disabled by setting `Logger.maxHierarchyDepth <=0`.
 
 **Rationale**: In performance-critical paths (e.g., hot event loops, high-throughput message handlers), every microsecond matters. Freezing allows developers to opt into zero-overhead logging, while diagnostics warnings and unfreezing tools keep the configuration lifecycle clean and manageable.
 

--- a/doc/logger/roadmap.md
+++ b/doc/logger/roadmap.md
@@ -230,7 +230,7 @@ Depends on Phase 1 (particularly the freeze no-op fix).
 **TODO**:
 - [x] Design bulk configuration API
 - [x] **Option A**: `Logger.configureMultiple(Map<String, LoggerConfig>)`
-- [ ] **Option B**: `Logger.configurePattern(pattern: 'app.*', ...)`
+- [x] **Option B**: `Logger.configurePattern(pattern: 'app.*', ...)`
 - [x] Ensure cache invalidation is batched (single pass, not N passes)
 - [x] Add tests and documentation
 
@@ -398,6 +398,7 @@ Resolved by switch to `parse()` — configured parser is always used.
 | Inheritance maturation | v0.8.2 | Added selective unfreeze, freeze force option, monitoring visualizer |
 | Descendant invalidation reverse-index | v0.8.3 | Replaced cache invalidation linear scanning with O(m) descendant index |
 | Pure-Dart & Flutter Decoupling | v0.8.4 | Removed Flutter SDK dependency, deleted conditional stubs, and switched to manual hook setup |
+| Bulk & Pattern-Based Configurations | v0.8.5 | Implemented `configureMultiple` and `configurePattern` with glob-style matching |
 
 ---
 

--- a/doc/logger/roadmap.md
+++ b/doc/logger/roadmap.md
@@ -228,11 +228,11 @@ Depends on Phase 1 (particularly the freeze no-op fix).
 **Issue**: Configuring multiple loggers requires multiple calls.
 
 **TODO**:
-- [ ] Design bulk configuration API
-- [ ] **Option A**: `Logger.configureMultiple(Map<String, LoggerConfig>)`
+- [x] Design bulk configuration API
+- [x] **Option A**: `Logger.configureMultiple(Map<String, LoggerConfig>)`
 - [ ] **Option B**: `Logger.configurePattern(pattern: 'app.*', ...)`
-- [ ] Ensure cache invalidation is batched (single pass, not N passes)
-- [ ] Add tests and documentation
+- [x] Ensure cache invalidation is batched (single pass, not N passes)
+- [x] Add tests and documentation
 
 ---
 

--- a/doc/logger/roadmap.md
+++ b/doc/logger/roadmap.md
@@ -192,7 +192,7 @@ Depends on Phase 1 (particularly the freeze no-op fix).
   - Option A: Skip them
   - Option B: Allow registration of serializers
 - [x] Add tests
-- [ ] Document isolate coordination pattern
+- [x] Document isolate coordination pattern
 
 ---
 
@@ -300,15 +300,15 @@ Depends on Phase 1 (particularly the freeze no-op fix).
 
 ---
 
-### 🔵 P3: Add Hierarchy Depth Warning
+### ~~🔵 P3: Add Hierarchy Depth Warning~~ ✅ v0.8.5
 
 **Issue**: No protection against accidentally deep hierarchies.
 
 **TODO**:
-- [ ] Define threshold (e.g., 10 levels)
-- [ ] Log InternalLogger warning on first access of deep logger
-- [ ] Make threshold configurable
-- [ ] Document in philosophy.md
+- [x] Define threshold (e.g., 10 levels)
+- [x] Log InternalLogger warning on first access of deep logger
+- [x] Make threshold configurable
+- [x] Document in philosophy.md
 
 ---
 

--- a/doc/stack_trace/README.md
+++ b/doc/stack_trace/README.md
@@ -51,7 +51,7 @@ The stack_trace module consists of 4 source files:
 
 #### [callback_info.dart](../../packages/logd/lib/src/stack_trace/callback_info.dart)
 - **`CallbackInfo`** - Immutable data class representing a parsed stack frame
-- Contains: class name, method name, file path, line number, full method string
+- Contains: class name, method name, file path, line number, column number (nullable), full method string
 - Provides equality and hash code implementations
 
 #### [stack_trace.dart](../../packages/logd/lib/src/stack_trace/stack_trace.dart)
@@ -118,6 +118,7 @@ const StackTraceParser({
 - `methodName` - Method or function name
 - `filePath` - File URI where call occurred
 - `lineNumber` - Line number in file
+- `columnNumber` - Column number in file (nullable, null if not provided)
 - `fullMethod` - Complete method string (e.g., 'Class.method')
 
 ## Integration with Logger

--- a/doc/stack_trace/architecture.md
+++ b/doc/stack_trace/architecture.md
@@ -52,6 +52,7 @@ An immutable data class representing a single parsed stack frame.
 - `methodName` - Method or function name
 - `filePath` - File URI from the stack frame
 - `lineNumber` - Line number as integer
+- `columnNumber` - Column number as integer (nullable, null if not provided or supported)
 - `fullMethod` - Complete method string (e.g., `'Class.method'`)
 
 **Immutability**: Marked `@immutable` with all fields `final`, implements proper `==` and `hashCode`.
@@ -162,14 +163,14 @@ bool _shouldIgnoreFrame(String frame) {
 
 **Regex Pattern**:
 ```dart
-static final _frameRegex = RegExp(r'#\d+\s+(.+)\s+\((.+):(\d+)(?::\d+)?\)');
+static final _vmRegex = RegExp(r'#\d+\s+(.+)\s+\((.+?):(\d+)(?::(\d+))?\)');
 ```
 
 **Capture Groups**:
 - Group 1: Function name (`MyClass.myMethod`)
 - Group 2: File URI (`package:myapp/service.dart`)
 - Group 3: Line number (`42`)
-- Group 4: Column number (optional, currently ignored)
+- Group 4: Column number (optional, `7`)
 
 **Class/Method Extraction**:
 ```dart
@@ -203,7 +204,16 @@ Error
 ```
 - Anonymous frames (no `at Identifier`) produce `methodName: '<anonymous>'`
 
-**Regex**: `^\s*at\s+(?:(.+)\s+\((.+):(\d+):\d+\)|(.+):(\d+):\d+)$`
+**Regex 1 (Named)**: `^\s*at\s+([^\s(]+)\s+\((.+?):(\d+):(\d+)\)`
+- Group 1: Function name
+- Group 2: File URI
+- Group 3: Line number
+- Group 4: Column number
+
+**Regex 2 (Anonymous)**: `^\s*at\s+(.+?):(\d+):(\d+)`
+- Group 1: File URI
+- Group 2: Line number
+- Group 3: Column number
 
 ### Firefox / Safari
 ```
@@ -212,7 +222,16 @@ http://localhost:8080/main.dart.js:678:90
 ```
 - Frames with no `@method` prefix produce `methodName: '<anonymous>'`
 
-**Regex**: `^(?:(.+)@)?(.+):(\d+):\d+$`
+**Regex 1 (Named)**: `^([^@\s]+)@(.+?):(\d+):(\d+)`
+- Group 1: Function name
+- Group 2: File URI
+- Group 3: Line number
+- Group 4: Column number
+
+**Regex 2 (Anonymous)**: `^(.+?):(\d+):(\d+)`
+- Group 1: File URI
+- Group 2: Line number
+- Group 3: Column number
 
 ### Package Filtering for Web Frames
 The `ignorePackages` list works for web frames via the `/packages/<pkg>/` path segment:

--- a/doc/stack_trace/roadmap.md
+++ b/doc/stack_trace/roadmap.md
@@ -145,17 +145,17 @@ class StackTraceParser {
 
 ---
 
-### Column Information Preservation
+### ~~Column Information Preservation~~ ✅ v0.8.5
 **Current**: Column numbers are parsed but discarded.
 
 **Regex**: `#\d+\s+(.+)\s+\((.+):(\d+)(?::\d+)?\)`
 - Group 4 (column) is optional and not captured
 
 **TODO**:
-- [ ] Add `columnNumber` field to `CallbackInfo`
-- [ ] Update regex to capture column
-- [ ] Handle platforms that don't provide column info
-- [ ] Update tests and documentation
+- [x] Add `columnNumber` field to `CallbackInfo`
+- [x] Update regex to capture column
+- [x] Handle platforms that don't provide column info
+- [x] Update tests and documentation
 
 **Acceptance Criteria**:
 - Column information available when provided

--- a/packages/benchmarks/records/benchmark_20260629_111827.md
+++ b/packages/benchmarks/records/benchmark_20260629_111827.md
@@ -1,0 +1,73 @@
+# Benchmark Report
+**Commit:** a4c9d5a Merge pull request #44 from pooriaaskarim/dev
+**Branch:** master
+**Dart:** Dart SDK version: 3.12.0 (stable) (Fri May 8 01:51:14 2026 -0700) on "linux_x64"
+
+```text
+Running Baseline Benchmarks...
+==============================
+
+--- Formatter Throughput ---
+PlainFormatter(RunTime): 220.63377630121815 us.
+StructuredFormatter(RunTime): 342.82979851537647 us.
+ToonFormatter(RunTime): 365.6963210702341 us.
+JsonFormatter(RunTime): 375.2325 us.
+JsonPrettyFormatter(RunTime): 879.256 us.
+MarkdownEncoder(RunTime): 41.33065669343306 us.
+
+--- Decorator Overhead ---
+BoxDecorator(RunTime): 582.6309000293169 us.
+PrefixDecorator(RunTime): 695.3495 us.
+StyleDecorator(RunTime): 8.076889846220308 us.
+SuffixDecorator(RunTime): 707.547 us.
+HierarchyDepthPrefixDecorator(RunTime): 797.934 us.
+
+--- Pipeline Throughput ---
+FullPipeline(RunTime): 2.468462308431897 us.
+ArenaFullPipeline(RunTime): 3.882402042143474 us.
+ManualPipeline(RunTime): 659.236 us.
+
+--- Multi-Sink Scaling ---
+MultiSink (x1)(RunTime): 29.68870222595548 us.
+MultiSink (x2)(RunTime): 29.08244117023532 us.
+MultiSink (x4)(RunTime): 26.287089779868435 us.
+
+--- Cache Invalidation Performance ---
+Descendant Invalidation (10,000 Unrelated, 1 Descendant)(RunTime): 24.642475446905692 us.
+
+--- Phase 1: Native Offload Scaling (10k iterations) ---
+[logd-internal] [WARNING]: Arena saturation reached (200 packets). Blocking main thread.
+[logd-internal] [WARNING]: Blocked main thread for 33ms waiting for pool capacity.
+
+--- Phase 1: Native Offload Scaling (10k iterations) ---
+  Progress: 0/10000
+  Progress: 1000/10000
+  Progress: 2000/10000
+  Progress: 3000/10000
+  Progress: 4000/10000
+  Progress: 5000/10000
+  Progress: 6000/10000
+  Progress: 7000/10000
+  Progress: 8000/10000
+  Progress: 9000/10000
+NativeEngineOffload (Phase 1): 53.22 us/op
+
+--- Stress Test & Profiling ---
+### 1. The Raw Machine (JSON -> FileSink)
+Profiling: Raw Machine ...
+11447 Ops/sec | p90: 131.00µs | p95: 147.00µs | p99: 184.00µs | GC Pressure: 151.20 KB/10k
+
+### 2. The Modern Human (Structured -> Box -> ConsoleSink)
+Profiling: Modern Human ...
+9728 Ops/sec | p90: 140.00µs | p95: 162.00µs | p99: 207.00µs | GC Pressure: 0.00 KB/10k
+
+### 3. The Framing Squeeze (Prefix -> Box -> ConsoleSink @ 40 width)
+Profiling: Framing Squeeze ...
+2863 Ops/sec | p90: 449.00µs | p95: 554.00µs | p99: 761.00µs | GC Pressure: 186.40 KB/10k
+
+
+--- Structural Efficiency Report ---
+Error: VM Service not enabled. Run with --observe or --enable-vm-service.
+==============================
+Benchmarks Complete.
+```

--- a/packages/benchmarks/records/benchmark_20260630_115334.md
+++ b/packages/benchmarks/records/benchmark_20260630_115334.md
@@ -1,0 +1,73 @@
+# Benchmark Report
+**Commit:** f9c66f7 docs: update stacktrace docs for columnNumber and document maxHierarchyDepth disabling
+**Branch:** dev
+**Dart:** Dart SDK version: 3.12.0 (stable) (Fri May 8 01:51:14 2026 -0700) on "linux_x64"
+
+```text
+Running Baseline Benchmarks...
+==============================
+
+--- Formatter Throughput ---
+PlainFormatter(RunTime): 246.79834254143645 us.
+StructuredFormatter(RunTime): 401.5322101090188 us.
+ToonFormatter(RunTime): 361.92 us.
+JsonFormatter(RunTime): 393.34350663018313 us.
+JsonPrettyFormatter(RunTime): 1052.35 us.
+MarkdownEncoder(RunTime): 50.48227447379232 us.
+
+--- Decorator Overhead ---
+BoxDecorator(RunTime): 760.79775 us.
+PrefixDecorator(RunTime): 889.944 us.
+StyleDecorator(RunTime): 7.897173757065607 us.
+SuffixDecorator(RunTime): 898.542 us.
+HierarchyDepthPrefixDecorator(RunTime): 768.82875 us.
+
+--- Pipeline Throughput ---
+FullPipeline(RunTime): 2.7806989005122045 us.
+ArenaFullPipeline(RunTime): 4.184763299680912 us.
+ManualPipeline(RunTime): 689.5633333333334 us.
+
+--- Multi-Sink Scaling ---
+MultiSink (x1)(RunTime): 27.42588188000402 us.
+MultiSink (x2)(RunTime): 30.243293796943423 us.
+MultiSink (x4)(RunTime): 29.14966925165374 us.
+
+--- Cache Invalidation Performance ---
+Descendant Invalidation (10,000 Unrelated, 1 Descendant)(RunTime): 27.653537887184275 us.
+
+--- Phase 1: Native Offload Scaling (10k iterations) ---
+[logd-internal] [WARNING]: Arena saturation reached (200 packets). Blocking main thread.
+[logd-internal] [WARNING]: Blocked main thread for 31ms waiting for pool capacity.
+
+--- Phase 1: Native Offload Scaling (10k iterations) ---
+  Progress: 0/10000
+  Progress: 1000/10000
+  Progress: 2000/10000
+  Progress: 3000/10000
+  Progress: 4000/10000
+  Progress: 5000/10000
+  Progress: 6000/10000
+  Progress: 7000/10000
+  Progress: 8000/10000
+  Progress: 9000/10000
+NativeEngineOffload (Phase 1): 58.30 us/op
+
+--- Stress Test & Profiling ---
+### 1. The Raw Machine (JSON -> FileSink)
+Profiling: Raw Machine ...
+12531 Ops/sec | p90: 114.00µs | p95: 128.00µs | p99: 173.00µs | GC Pressure: 262.40 KB/10k
+
+### 2. The Modern Human (Structured -> Box -> ConsoleSink)
+Profiling: Modern Human ...
+10600 Ops/sec | p90: 111.00µs | p95: 135.00µs | p99: 178.00µs | GC Pressure: 0.00 KB/10k
+
+### 3. The Framing Squeeze (Prefix -> Box -> ConsoleSink @ 40 width)
+Profiling: Framing Squeeze ...
+3381 Ops/sec | p90: 331.00µs | p95: 388.00µs | p99: 618.00µs | GC Pressure: 186.40 KB/10k
+
+
+--- Structural Efficiency Report ---
+Error: VM Service not enabled. Run with --observe or --enable-vm-service.
+==============================
+Benchmarks Complete.
+```

--- a/packages/logd/CHANGELOG.md
+++ b/packages/logd/CHANGELOG.md
@@ -17,6 +17,12 @@ This release introduces the bulk configuration API to enable efficient, batched 
   - **Dynamic Walker Resolution**: Evaluates pattern rules dynamically during the logger resolution path, maintaining strict hierarchical precedence while allowing newer pattern rules to override older ones.
   - **Isolate Serialization Integration**: Supported exporting and importing pattern configuration rules seamlessly across isolates via `Logger.exportConfig()` and `Logger.importConfig()`.
 
+- ### Stack Trace & Diagnostics Enhancements
+  - **Column Number Preservation**: Added `columnNumber` field to `CallbackInfo` and updated `StackTraceParser` regex/parsing logic to capture and preserve column numbers across VM, Chrome (V8), Firefox, and Safari environments for high-fidelity source map resolution and deobfuscation.
+  - **Hierarchy Depth Warning**: Added a safeguard that alerts developers via an `InternalLogger` warning on first access to abnormally deep logger hierarchies (defaulting to >10 levels) to prevent potential stack overflows and performance degradation.
+  - **Configurable Safety Threshold**: Introduced `Logger.maxHierarchyDepth` to customize or disable the hierarchy depth warning threshold.
+  - **Isolate Coordination Documentation**: Authored a comprehensive integration guide (`doc/logger/isolates.md`) detailing how to coordinate logger configurations dynamically across worker isolates and register custom pipeline components.
+
 ## 0.8.4: Core Logger Enhancements, Web Stack Trace, Time Caching, Testing Utilities & Flutter Decoupling
 
 This release introduces major updates to mature the core logger configuration, transports, observability, testing infrastructure, time performance caching, and cross-platform web/Windows runtime compatibility. It also decouples the logging pipeline from the Flutter SDK for pure Dart CLI/VM support, optimizes decorator layout width calculations, and adds a context filter.

--- a/packages/logd/CHANGELOG.md
+++ b/packages/logd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.5: Bulk Configuration API & Optimized Cache Invalidation
+
+This release introduces the bulk configuration API to enable efficient, batched logger updates and centralized cache invalidation.
+
+- ### Core Configuration API
+  - **Logger.configureMultiple**: Added a new static method `Logger.configureMultiple(Map<String, LoggerConfig> configurations)` to allow configuring multiple loggers in a single operation.
+  - **Single-Pass Cache Invalidation**: Implemented `LoggerCache.invalidateMultiple` to batch descendant cache invalidations, avoiding $O(N^2)$ traversal costs and minimizing tree-walk operations.
+  - **Atomic Input Validation**: Validation of all logger configurations happens atomically before any registry modifications are made, ensuring that the entire batch either succeeds or fails.
+  - **LoggerConfig Export**: Exposed `LoggerConfig` in the public API (`packages/logd/lib/logd.dart`) to support programmatic configuration construction for bulk updates.
+  - **Logger.configure Delegation**: Refactored `Logger.configure` to delegate to `Logger.configureMultiple` for architectural consistency.
+
 ## 0.8.4: Core Logger Enhancements, Web Stack Trace, Time Caching, Testing Utilities & Flutter Decoupling
 
 This release introduces major updates to mature the core logger configuration, transports, observability, testing infrastructure, time performance caching, and cross-platform web/Windows runtime compatibility. It also decouples the logging pipeline from the Flutter SDK for pure Dart CLI/VM support, optimizes decorator layout width calculations, and adds a context filter.

--- a/packages/logd/CHANGELOG.md
+++ b/packages/logd/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.8.5: Bulk Configuration API & Optimized Cache Invalidation
+## 0.8.5: Bulk & Pattern-Based Configuration APIs
 
-This release introduces the bulk configuration API to enable efficient, batched logger updates and centralized cache invalidation.
+This release introduces the bulk configuration API to enable efficient, batched logger updates, as well as pattern-based configuration for wildcard matching across logger hierarchies.
 
 - ### Core Configuration API
   - **Logger.configureMultiple**: Added a new static method `Logger.configureMultiple(Map<String, LoggerConfig> configurations)` to allow configuring multiple loggers in a single operation.
@@ -10,6 +10,12 @@ This release introduces the bulk configuration API to enable efficient, batched 
   - **Atomic Input Validation**: Validation of all logger configurations happens atomically before any registry modifications are made, ensuring that the entire batch either succeeds or fails.
   - **LoggerConfig Export**: Exposed `LoggerConfig` in the public API (`packages/logd/lib/logd.dart`) to support programmatic configuration construction for bulk updates.
   - **Logger.configure Delegation**: Refactored `Logger.configure` to delegate to `Logger.configureMultiple` for architectural consistency.
+
+- ### Wildcard Pattern Matching Configuration
+  - **Logger.configurePattern**: Added a new static method `Logger.configurePattern(String pattern, ...)` to configure loggers matching a wildcard or regular expression pattern.
+  - **Glob Wildcard Syntax**: Supports suffix matching (e.g., `*.database`), prefix/infix matching (e.g., `app.services.*`), and global wildcards (e.g., `*`).
+  - **Dynamic Walker Resolution**: Evaluates pattern rules dynamically during the logger resolution path, maintaining strict hierarchical precedence while allowing newer pattern rules to override older ones.
+  - **Isolate Serialization Integration**: Supported exporting and importing pattern configuration rules seamlessly across isolates via `Logger.exportConfig()` and `Logger.importConfig()`.
 
 ## 0.8.4: Core Logger Enhancements, Web Stack Trace, Time Caching, Testing Utilities & Flutter Decoupling
 

--- a/packages/logd/README.md
+++ b/packages/logd/README.md
@@ -91,6 +91,22 @@ Logger.configureMultiple({
 * **Atomic Validation**: Input validation occurs across the entire configuration map *before* any updates are written. If a single configuration fails (e.g., negative stack trace count), the entire update is cleanly rejected.
 * **Single-Pass Cache Invalidation**: The cache is invalidated in a single optimized pass for all changed loggers and their descendants, eliminating redundant tree-walks and reducing GC pressure.
 
+### Pattern-Based Configuration
+
+When you want to apply configurations to loggers that don't share a strict parent-child relationship or to match loggers dynamically across your application using wildcards, you can use `configurePattern`. It supports standard glob wildcards (`*` matches zero or more characters, `?` matches a single character).
+
+```dart
+// Configure all database loggers to DEBUG
+Logger.configurePattern('*.database', logLevel: LogLevel.debug);
+
+// Disable all third-party package loggers under a prefix
+Logger.configurePattern('vendor.*', enabled: false);
+
+// Wildcard matches are evaluated dynamically on cache resolution,
+// with newer pattern rules overriding older ones if they both match.
+Logger.configurePattern('app.services.*', logLevel: LogLevel.info);
+```
+
 ### Log levels
 
 | Level | Description |

--- a/packages/logd/README.md
+++ b/packages/logd/README.md
@@ -14,7 +14,7 @@ A <b> modular</b> <b>hierarchical</b> logger for Dart and Flutter. Build structu
 - **Flexible output** – Choose between console, file, network, HTML, or any custom sink; format logs as text, structured JSON, HTML, Markdown or **LLM‑optimized TOON**.
 - **Layout Sovereignty** – A centralized engine guarantees structural integrity (e.g., perfect boxes) across all terminal widths.
 - **Platform‑agnostic styling** – Decouple visual intent from representation using the semantic `LogTheme` system.
-- **Web & Desktop Parity** – Built-in platform-aware stack trace parsers for Chrome (V8), Firefox, Safari, and the Dart VM.
+- **Web & Desktop Parity** – Built-in platform-aware stack trace parsers for Chrome (V8), Firefox, Safari, and the Dart VM, preserving column numbers for high-fidelity source map resolution.
 
 ## Getting Started
 
@@ -280,6 +280,10 @@ Logger.get('app').freezeInheritance();
   ```dart
   Logger.reset('app.ui'); // Resets only 'app.ui' and its descendants
   Logger.reset();        // Global reset, clears the entire registry
+  ```
+- **Hierarchy Depth Warning (v0.8.5+)**: Accessing loggers with abnormally deep hierarchies (e.g. >10 levels) prints an `InternalLogger` warning on first access to protect against stack overflows and resolution performance issues. This threshold is customizable:
+  ```dart
+  Logger.maxHierarchyDepth = 12; // Customize safety limit
   ```
 
 ### Isolate Configuration Transport (v0.8.4+)

--- a/packages/logd/README.md
+++ b/packages/logd/README.md
@@ -285,7 +285,7 @@ Logger.get('app').freezeInheritance();
   ```dart
   Logger.maxHierarchyDepth = 12; // Customize safety limit
   ```
-  This can be disabled by setting `Logger.maxHierarchyDepth` to `0`.
+  This can be disabled by setting `Logger.maxHierarchyDepth <= 0`.
 
 ### Isolate Configuration Transport (v0.8.4+)
 

--- a/packages/logd/README.md
+++ b/packages/logd/README.md
@@ -285,6 +285,7 @@ Logger.get('app').freezeInheritance();
   ```dart
   Logger.maxHierarchyDepth = 12; // Customize safety limit
   ```
+  This can be disabled by setting `Logger.maxHierarchyDepth` to `0`.
 
 ### Isolate Configuration Transport (v0.8.4+)
 

--- a/packages/logd/README.md
+++ b/packages/logd/README.md
@@ -76,6 +76,21 @@ final uiLogger = Logger.get('app.ui.button');  // inherits WARNING
 final httpLogger = Logger.get('app.network.http'); // inherits DEBUG
 ```
 
+### Bulk Configuration
+
+For complex or large applications, configuring multiple loggers individually can lead to boilerplate and redundant cache invalidation traversals. You can use the bulk configuration API to apply multiple updates at once:
+
+```dart
+Logger.configureMultiple({
+  'global': const LoggerConfig(logLevel: LogLevel.warning),
+  'app.network': const LoggerConfig(logLevel: LogLevel.debug),
+  'app.ui': const LoggerConfig(enabled: false),
+});
+```
+
+* **Atomic Validation**: Input validation occurs across the entire configuration map *before* any updates are written. If a single configuration fails (e.g., negative stack trace count), the entire update is cleanly rejected.
+* **Single-Pass Cache Invalidation**: The cache is invalidated in a single optimized pass for all changed loggers and their descendants, eliminating redundant tree-walks and reducing GC pressure.
+
 ### Log levels
 
 | Level | Description |

--- a/packages/logd/lib/logd.dart
+++ b/packages/logd/lib/logd.dart
@@ -12,7 +12,7 @@ export 'src/handler/handler.dart'
         PrintSink,
         RenderTokens,
         TerminalLayout;
-export 'src/logger/logger.dart' hide InternalLogger, LoggerCache, LoggerConfig;
+export 'src/logger/logger.dart' hide InternalLogger, LoggerCache;
 export 'src/stack_trace/stack_trace.dart' hide CallbackInfo, StackFrameSet;
 export 'src/time/timestamp.dart'
     hide TimestampFormatter, TimestampFormatterCache;

--- a/packages/logd/lib/src/logger/logger.dart
+++ b/packages/logd/lib/src/logger/logger.dart
@@ -17,6 +17,9 @@ part 'log_buffer.dart';
 part 'log_entry.dart';
 part 'serialization_registry.dart';
 
+const String _globalLoggerName = 'global';
+const int _logMethodSkipFrames = 1;
+
 /// Configuration overrides for a [Logger], holding optional fields that
 /// can inherit from parent.
 @immutable
@@ -252,14 +255,14 @@ class LoggerCache {
   static final Map<String, Set<String>> _descendants = {};
 
   static List<String> _getAncestors(final String loggerName) {
-    if (loggerName == 'global') {
+    if (loggerName == _globalLoggerName) {
       return const [];
     }
-    final ancestors = <String>['global'];
+    final ancestors = <String>[_globalLoggerName];
     var current = loggerName;
     while (true) {
       final parent = Logger._getParentName(current);
-      if (parent == null || parent == 'global') {
+      if (parent == null || parent == _globalLoggerName) {
         break;
       }
       ancestors.add(parent);
@@ -598,7 +601,8 @@ class Logger {
     if (maxHierarchyDepth <= 0) {
       return;
     }
-    final depth = normalized == 'global' ? 0 : normalized.split('.').length;
+    final depth =
+        normalized == _globalLoggerName ? 0 : normalized.split('.').length;
     if (depth > maxHierarchyDepth) {
       if (_warnedDeepLoggers.add(normalized)) {
         InternalLogger.log(
@@ -1082,8 +1086,8 @@ class Logger {
 
   /// Internal: Checks if a name is a descendant of parent.
   static bool _isDescendant(final String child, final String parent) {
-    if (parent == 'global') {
-      return child != 'global';
+    if (parent == _globalLoggerName) {
+      return child != _globalLoggerName;
     }
     return child.startsWith('$parent.');
   }
@@ -1733,7 +1737,7 @@ class Logger {
     final frameCount = stackMethodCount[level] ?? 0;
     final parsed = stackTraceParser.parse(
       stackTrace: stackTrace ?? StackTrace.current,
-      skipFrames: 1,
+      skipFrames: _logMethodSkipFrames,
       maxFrames: frameCount,
     );
     if (parsed.caller == null) {
@@ -1807,12 +1811,12 @@ class Logger {
 
   /// Internal: Helper for retrieving parent name.
   static String? _getParentName(final String name) {
-    if (name == 'global') {
+    if (name == _globalLoggerName) {
       return null;
     }
     final lastDot = name.lastIndexOf('.');
     if (lastDot == -1) {
-      return 'global';
+      return _globalLoggerName;
     }
     return name.substring(0, lastDot);
   }
@@ -1821,8 +1825,8 @@ class Logger {
   ///
   /// Resolves null, empty strings and any form of 'global' to 'global'.
   static String _normalizeName([final String? name]) {
-    final lower = name?.toLowerCase() ?? 'global';
-    final normalized = lower.isEmpty ? 'global' : lower;
+    final lower = name?.toLowerCase() ?? _globalLoggerName;
+    final normalized = lower.isEmpty ? _globalLoggerName : lower;
 
     if (!_nameRegex.hasMatch(normalized)) {
       throw ArgumentError.value(
@@ -1847,8 +1851,9 @@ class Logger {
   /// WARNING: This will remove custom configurations and cached resolution
   /// states.
   static void reset([final String? loggerName]) {
-    final name = loggerName == null ? 'global' : _normalizeName(loggerName);
-    if (name == 'global') {
+    final name =
+        loggerName == null ? _globalLoggerName : _normalizeName(loggerName);
+    if (name == _globalLoggerName) {
       _registry.clear();
       _patternRules.clear();
       LoggerCache.clear();

--- a/packages/logd/lib/src/logger/logger.dart
+++ b/packages/logd/lib/src/logger/logger.dart
@@ -553,6 +553,12 @@ class Logger {
   /// Internal: Registered pattern configuration rules.
   static final List<_PatternRule> _patternRules = [];
 
+  /// The maximum hierarchy depth allowed before a warning is printed.
+  /// Defaults to 10.
+  static int maxHierarchyDepth = 10;
+
+  static final Set<String> _warnedDeepLoggers = {};
+
   /// Callback triggered when all configured handlers fail.
   ///
   /// Defaults to printing a formatted message to standard output.
@@ -588,6 +594,21 @@ class Logger {
     }
   }
 
+  static void _checkHierarchyDepth(final String normalized) {
+    final depth = normalized == 'global' ? 0 : normalized.split('.').length;
+    if (depth > maxHierarchyDepth) {
+      if (_warnedDeepLoggers.add(normalized)) {
+        InternalLogger.log(
+          LogLevel.warning,
+          'Logger hierarchy depth for "$normalized" is $depth, which exceeds '
+          'the maximum recommended threshold of $maxHierarchyDepth. '
+          'Deep logger hierarchies can cause performance degradation or '
+          'stack overflows during configuration resolution.',
+        );
+      }
+    }
+  }
+
   /// - Basic: Logger.get('app').info('Message');
   /// - Global: Logger.get(), Logger.get(''), Logger.get('global')
   ///
@@ -597,6 +618,7 @@ class Logger {
   static Logger get([final String? name]) {
     final normalized = _normalizeName(name);
     _registerLogger(normalized);
+    _checkHierarchyDepth(normalized);
     return Logger._(normalized);
   }
 
@@ -1827,6 +1849,7 @@ class Logger {
       _registry.clear();
       _patternRules.clear();
       LoggerCache.clear();
+      _warnedDeepLoggers.clear();
     } else {
       LoggerCache.invalidate(name);
       _registry.remove(name);

--- a/packages/logd/lib/src/logger/logger.dart
+++ b/packages/logd/lib/src/logger/logger.dart
@@ -595,6 +595,9 @@ class Logger {
   }
 
   static void _checkHierarchyDepth(final String normalized) {
+    if (maxHierarchyDepth <= 0) {
+      return;
+    }
     final depth = normalized == 'global' ? 0 : normalized.split('.').length;
     if (depth > maxHierarchyDepth) {
       if (_warnedDeepLoggers.add(normalized)) {

--- a/packages/logd/lib/src/logger/logger.dart
+++ b/packages/logd/lib/src/logger/logger.dart
@@ -17,9 +17,8 @@ part 'log_buffer.dart';
 part 'log_entry.dart';
 part 'serialization_registry.dart';
 
-/// Internal configuration for a [Logger], holding optional fields that
+/// Configuration overrides for a [Logger], holding optional fields that
 /// can inherit from parent.
-@internal
 @immutable
 class LoggerConfig {
   factory LoggerConfig.fromJson(final Map<String, dynamic> json) {
@@ -438,6 +437,25 @@ class LoggerCache {
     }
   }
 
+  /// Invalidates the cache for multiple loggers and all their descendants in
+  /// a single pass.
+  static void invalidateMultiple(final Iterable<String> loggerNames) {
+    final keysToInvalidate = <String>{};
+    for (final name in loggerNames) {
+      final normalized = Logger._normalizeName(name);
+      keysToInvalidate.add(normalized);
+      final descendantsList = _descendants[normalized];
+      if (descendantsList != null) {
+        keysToInvalidate.addAll(descendantsList);
+      }
+    }
+    for (final key in keysToInvalidate) {
+      if (_cache.remove(key) != null) {
+        LoggerMetrics._cacheInvalidations++;
+      }
+    }
+  }
+
   /// Clears the entire logger cache.
   static void clear() {
     LoggerMetrics._cacheInvalidations += _cache.length;
@@ -581,190 +599,253 @@ class Logger {
     final List<Handler>? handlers,
     final bool? autoSinkBuffer,
   }) {
-    // Input validation
-    if (stackMethodCount != null) {
-      for (final entry in stackMethodCount.entries) {
-        if (entry.value < 0) {
-          throw ArgumentError.value(
-            entry.value,
-            'stackMethodCount[${entry.key}]',
-            'Stack method count cannot be negative',
-          );
+    configureMultiple({
+      name: LoggerConfig(
+        enabled: enabled,
+        logLevel: logLevel,
+        includeFileLineInHeader: includeFileLineInHeader,
+        stackMethodCount: stackMethodCount,
+        timestamp: timestamp,
+        stackTraceParser: stackTraceParser,
+        handlers: handlers,
+        autoSinkBuffer: autoSinkBuffer,
+      ),
+    });
+  }
+
+  /// Configures multiple loggers at once, applying their properties in-place.
+  ///
+  /// This method is more efficient than calling [configure] multiple times
+  /// as it performs cache invalidation in a single batched pass.
+  ///
+  /// Parameters:
+  /// - [configurations]: A map of logger names to their desired [LoggerConfig].
+  ///
+  /// Throws [ArgumentError] if:
+  /// - Any [stackMethodCount] value is negative.
+  /// - [handlers] is an empty list.
+  ///
+  /// Example:
+  ///   Logger.configureMultiple({
+  ///     'global': const LoggerConfig(logLevel: LogLevel.warning),
+  ///     'app.network': const LoggerConfig(logLevel: LogLevel.debug),
+  ///   });
+  static void configureMultiple(
+    final Map<String, LoggerConfig> configurations,
+  ) {
+    if (configurations.isEmpty) {
+      return;
+    }
+
+    // First validate all inputs to ensure correctness/atomicity
+    for (final entry in configurations.entries) {
+      final config = entry.value;
+      if (config.stackMethodCount != null) {
+        for (final smcEntry in config.stackMethodCount!.entries) {
+          if (smcEntry.value < 0) {
+            throw ArgumentError.value(
+              smcEntry.value,
+              'stackMethodCount[${smcEntry.key}]',
+              'Stack method count cannot be negative for logger '
+                  '"${entry.key}"',
+            );
+          }
         }
       }
-    }
-    if (handlers != null && handlers.isEmpty) {
-      throw ArgumentError.value(
-        handlers,
-        'handlers',
-        'Handlers list cannot be empty',
-      );
-    }
-
-    final normalized = _normalizeName(name);
-    _registerLogger(normalized);
-    final config = _registry[normalized]!;
-
-    bool changed = false;
-    final frozenFields = Set<String>.from(config.frozenFields);
-
-    bool? newEnabled = config.enabled;
-    if (enabled != null) {
-      final removed = frozenFields.remove('enabled');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'enabled' was frozen; configure() has promoted "
-          "it to explicit. Call unfreezeInheritance() first to restore dynamic "
-          'resolution instead.',
+      if (config.handlers != null && config.handlers!.isEmpty) {
+        throw ArgumentError.value(
+          config.handlers,
+          'handlers',
+          'Handlers list cannot be empty for logger "${entry.key}"',
         );
       }
-      if (enabled != config.enabled || removed) {
-        newEnabled = enabled;
-        changed = true;
-      }
     }
 
-    LogLevel? newLogLevel = config.logLevel;
-    if (logLevel != null) {
-      final removed = frozenFields.remove('logLevel');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'logLevel' was frozen; configure() has promoted "
-          "it to explicit. Call unfreezeInheritance() first to restore dynamic "
-          'resolution instead.',
+    final changedLoggers = <String>{};
+
+    for (final entry in configurations.entries) {
+      final name = entry.key;
+      final newConfig = entry.value;
+      final normalized = _normalizeName(name);
+      _registerLogger(normalized);
+      final existingConfig = _registry[normalized]!;
+
+      bool changed = false;
+      final frozenFields = Set<String>.from(existingConfig.frozenFields);
+
+      bool? newEnabled = existingConfig.enabled;
+      if (newConfig.enabled != null) {
+        final removed = frozenFields.remove('enabled');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'enabled' was frozen; configure() has "
+            "promoted it to explicit. Call unfreezeInheritance() first to "
+            'restore dynamic resolution instead.',
+          );
+        }
+        if (newConfig.enabled != existingConfig.enabled || removed) {
+          newEnabled = newConfig.enabled;
+          changed = true;
+        }
+      }
+
+      LogLevel? newLogLevel = existingConfig.logLevel;
+      if (newConfig.logLevel != null) {
+        final removed = frozenFields.remove('logLevel');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'logLevel' was frozen; configure() has "
+            "promoted it to explicit. Call unfreezeInheritance() first to "
+            'restore dynamic resolution instead.',
+          );
+        }
+        if (newConfig.logLevel != existingConfig.logLevel || removed) {
+          newLogLevel = newConfig.logLevel;
+          changed = true;
+        }
+      }
+
+      bool? newIncludeFileLineInHeader =
+          existingConfig.includeFileLineInHeader;
+      if (newConfig.includeFileLineInHeader != null) {
+        final removed = frozenFields.remove('includeFileLineInHeader');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'includeFileLineInHeader' was frozen; "
+            'configure() has promoted it to explicit. Call '
+            'unfreezeInheritance() first to restore dynamic '
+            'resolution instead.',
+          );
+        }
+        if (newConfig.includeFileLineInHeader !=
+                existingConfig.includeFileLineInHeader ||
+            removed) {
+          newIncludeFileLineInHeader = newConfig.includeFileLineInHeader;
+          changed = true;
+        }
+      }
+
+      Map<LogLevel, int>? newStackMethodCount =
+          existingConfig.stackMethodCount;
+      if (newConfig.stackMethodCount != null) {
+        final removed = frozenFields.remove('stackMethodCount');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'stackMethodCount' was frozen; configure() "
+            "has promoted it to explicit. Call unfreezeInheritance() first "
+            'to restore dynamic resolution instead.',
+          );
+        }
+        if (!mapEquals(
+              newConfig.stackMethodCount,
+              existingConfig.stackMethodCount,
+            ) ||
+            removed) {
+          newStackMethodCount = newConfig.stackMethodCount;
+          changed = true;
+        }
+      }
+
+      Timestamp? newTimestamp = existingConfig.timestamp;
+      if (newConfig.timestamp != null) {
+        final removed = frozenFields.remove('timestamp');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'timestamp' was frozen; configure() has "
+            "promoted it to explicit. Call unfreezeInheritance() first to "
+            'restore dynamic resolution instead.',
+          );
+        }
+        if (newConfig.timestamp != existingConfig.timestamp || removed) {
+          newTimestamp = newConfig.timestamp;
+          changed = true;
+        }
+      }
+
+      StackTraceParser? newStackTraceParser = existingConfig.stackTraceParser;
+      if (newConfig.stackTraceParser != null) {
+        final removed = frozenFields.remove('stackTraceParser');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'stackTraceParser' was frozen; configure() "
+            "has promoted it to explicit. Call unfreezeInheritance() first "
+            'to restore dynamic resolution instead.',
+          );
+        }
+        if (newConfig.stackTraceParser != existingConfig.stackTraceParser ||
+            removed) {
+          newStackTraceParser = newConfig.stackTraceParser;
+          changed = true;
+        }
+      }
+
+      List<Handler>? newHandlers = existingConfig.handlers;
+      if (newConfig.handlers != null) {
+        final removed = frozenFields.remove('handlers');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'handlers' was frozen; configure() has "
+            "promoted it to explicit. Call unfreezeInheritance() first to "
+            'restore dynamic resolution instead.',
+          );
+        }
+        if (!listEquals(newConfig.handlers, existingConfig.handlers) ||
+            removed) {
+          newHandlers = newConfig.handlers;
+          changed = true;
+        }
+      }
+
+      bool? newAutoSinkBuffer = existingConfig.autoSinkBuffer;
+      if (newConfig.autoSinkBuffer != null) {
+        final removed = frozenFields.remove('autoSinkBuffer');
+        if (removed) {
+          InternalLogger.log(
+            LogLevel.warning,
+            "'$normalized' field 'autoSinkBuffer' was frozen; configure() "
+            "has promoted it to explicit. Call unfreezeInheritance() first "
+            'to restore dynamic resolution instead.',
+          );
+        }
+        if (newConfig.autoSinkBuffer != existingConfig.autoSinkBuffer ||
+            removed) {
+          newAutoSinkBuffer = newConfig.autoSinkBuffer;
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        _registry[normalized] = existingConfig.copyWith(
+          enabled: newEnabled,
+          logLevel: newLogLevel,
+          includeFileLineInHeader: newIncludeFileLineInHeader,
+          stackMethodCount: newStackMethodCount,
+          timestamp: newTimestamp,
+          stackTraceParser: newStackTraceParser,
+          handlers: newHandlers,
+          autoSinkBuffer: newAutoSinkBuffer,
+          version: existingConfig.version + 1,
+          frozenFields: frozenFields,
+          implicit: false,
+        );
+        changedLoggers.add(normalized);
+      } else {
+        _registry[normalized] = existingConfig.copyWith(
+          frozenFields: frozenFields,
+          implicit: false,
         );
       }
-      if (logLevel != config.logLevel || removed) {
-        newLogLevel = logLevel;
-        changed = true;
-      }
     }
 
-    bool? newIncludeFileLineInHeader = config.includeFileLineInHeader;
-    if (includeFileLineInHeader != null) {
-      final removed = frozenFields.remove('includeFileLineInHeader');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'includeFileLineInHeader' was frozen; "
-          'configure() has promoted it to explicit. Call '
-          'unfreezeInheritance() first to restore dynamic resolution instead.',
-        );
-      }
-      if (includeFileLineInHeader != config.includeFileLineInHeader ||
-          removed) {
-        newIncludeFileLineInHeader = includeFileLineInHeader;
-        changed = true;
-      }
-    }
-
-    Map<LogLevel, int>? newStackMethodCount = config.stackMethodCount;
-    if (stackMethodCount != null) {
-      final removed = frozenFields.remove('stackMethodCount');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'stackMethodCount' was frozen; configure() has "
-          "promoted it to explicit. Call unfreezeInheritance() first to "
-          'restore dynamic resolution instead.',
-        );
-      }
-      if (!mapEquals(stackMethodCount, config.stackMethodCount) || removed) {
-        newStackMethodCount = stackMethodCount;
-        changed = true;
-      }
-    }
-
-    Timestamp? newTimestamp = config.timestamp;
-    if (timestamp != null) {
-      final removed = frozenFields.remove('timestamp');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'timestamp' was frozen; configure() has "
-          "promoted it to explicit. Call unfreezeInheritance() first to "
-          'restore dynamic resolution instead.',
-        );
-      }
-      if (timestamp != config.timestamp || removed) {
-        newTimestamp = timestamp;
-        changed = true;
-      }
-    }
-
-    StackTraceParser? newStackTraceParser = config.stackTraceParser;
-    if (stackTraceParser != null) {
-      final removed = frozenFields.remove('stackTraceParser');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'stackTraceParser' was frozen; configure() has "
-          "promoted it to explicit. Call unfreezeInheritance() first to "
-          'restore dynamic resolution instead.',
-        );
-      }
-      if (stackTraceParser != config.stackTraceParser || removed) {
-        newStackTraceParser = stackTraceParser;
-        changed = true;
-      }
-    }
-
-    List<Handler>? newHandlers = config.handlers;
-    if (handlers != null) {
-      final removed = frozenFields.remove('handlers');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'handlers' was frozen; configure() has promoted "
-          "it to explicit. Call unfreezeInheritance() first to restore dynamic "
-          'resolution instead.',
-        );
-      }
-      if (!listEquals(handlers, config.handlers) || removed) {
-        newHandlers = handlers;
-        changed = true;
-      }
-    }
-
-    bool? newAutoSinkBuffer = config.autoSinkBuffer;
-    if (autoSinkBuffer != null) {
-      final removed = frozenFields.remove('autoSinkBuffer');
-      if (removed) {
-        InternalLogger.log(
-          LogLevel.warning,
-          "'$normalized' field 'autoSinkBuffer' was frozen; configure() has "
-          "promoted it to explicit. Call unfreezeInheritance() first to "
-          'restore dynamic resolution instead.',
-        );
-      }
-      if (autoSinkBuffer != config.autoSinkBuffer || removed) {
-        newAutoSinkBuffer = autoSinkBuffer;
-        changed = true;
-      }
-    }
-
-    if (changed) {
-      _registry[normalized] = config.copyWith(
-        enabled: newEnabled,
-        logLevel: newLogLevel,
-        includeFileLineInHeader: newIncludeFileLineInHeader,
-        stackMethodCount: newStackMethodCount,
-        timestamp: newTimestamp,
-        stackTraceParser: newStackTraceParser,
-        handlers: newHandlers,
-        autoSinkBuffer: newAutoSinkBuffer,
-        version: config.version + 1,
-        frozenFields: frozenFields,
-        implicit: false,
-      );
-      LoggerCache.invalidate(normalized);
-    } else {
-      _registry[normalized] = config.copyWith(
-        frozenFields: frozenFields,
-        implicit: false,
-      );
+    if (changedLoggers.isNotEmpty) {
+      LoggerCache.invalidateMultiple(changedLoggers);
     }
   }
 

--- a/packages/logd/lib/src/logger/logger.dart
+++ b/packages/logd/lib/src/logger/logger.dart
@@ -364,6 +364,31 @@ class LoggerCache {
         resolvedAutoSinkBuffer ??= cSource.autoSinkBuffer;
       }
 
+      if (Logger._patternRules.isNotEmpty) {
+        for (var i = Logger._patternRules.length - 1; i >= 0; i--) {
+          final rule = Logger._patternRules[i];
+          if (rule.regExp.hasMatch(currentName)) {
+            final pSource = rule.config;
+            resolvedEnabled ??= pSource.enabled;
+            resolvedLogLevel ??= pSource.logLevel;
+            resolvedIncludeFileLineInHeader ??= pSource.includeFileLineInHeader;
+            if (pSource.stackMethodCount != null) {
+              resolvedStackMethodCount ??= {};
+              for (final entry in pSource.stackMethodCount!.entries) {
+                resolvedStackMethodCount.putIfAbsent(
+                  entry.key,
+                  () => entry.value,
+                );
+              }
+            }
+            resolvedTimestamp ??= pSource.timestamp;
+            resolvedStackTraceParser ??= pSource.stackTraceParser;
+            resolvedHandlers ??= pSource.handlers;
+            resolvedAutoSinkBuffer ??= pSource.autoSinkBuffer;
+          }
+        }
+      }
+
       final parentName = Logger._getParentName(currentName);
       if (parentName == null) {
         break;
@@ -490,6 +515,20 @@ class _ResolvedConfig {
   final bool autoSinkBuffer;
 }
 
+/// Internal container for a pattern configuration rule.
+@immutable
+class _PatternRule {
+  const _PatternRule({
+    required this.pattern,
+    required this.regExp,
+    required this.config,
+  });
+
+  final String pattern;
+  final RegExp regExp;
+  final LoggerConfig config;
+}
+
 /// Main logd interface.
 ///
 /// Use this class for logging operations. It provides methods to retrieve
@@ -510,6 +549,9 @@ class Logger {
 
   /// Internal: Registry of all available logger configs.
   static final Map<String, LoggerConfig> _registry = {};
+
+  /// Internal: Registered pattern configuration rules.
+  static final List<_PatternRule> _patternRules = [];
 
   /// Callback triggered when all configured handlers fail.
   ///
@@ -707,8 +749,7 @@ class Logger {
         }
       }
 
-      bool? newIncludeFileLineInHeader =
-          existingConfig.includeFileLineInHeader;
+      bool? newIncludeFileLineInHeader = existingConfig.includeFileLineInHeader;
       if (newConfig.includeFileLineInHeader != null) {
         final removed = frozenFields.remove('includeFileLineInHeader');
         if (removed) {
@@ -728,8 +769,7 @@ class Logger {
         }
       }
 
-      Map<LogLevel, int>? newStackMethodCount =
-          existingConfig.stackMethodCount;
+      Map<LogLevel, int>? newStackMethodCount = existingConfig.stackMethodCount;
       if (newConfig.stackMethodCount != null) {
         final removed = frozenFields.remove('stackMethodCount');
         if (removed) {
@@ -849,6 +889,111 @@ class Logger {
     }
   }
 
+  /// Configures loggers matching a wildcard or regular expression pattern.
+  ///
+  /// This allows setting behavior on loggers without having to configure each
+  /// logger individually or depending on a strict dot-separated hierarchy.
+  ///
+  /// The pattern supports glob-style wildcards:
+  /// - `*` matches zero or more characters.
+  /// - `?` matches any single character.
+  ///
+  /// Throws [ArgumentError] if:
+  /// - [pattern] is empty.
+  /// - Any [stackMethodCount] value is negative.
+  /// - [handlers] is an empty list.
+  ///
+  /// Example:
+  ///   Logger.configurePattern('*.database', logLevel: LogLevel.debug);
+  static void configurePattern(
+    final String pattern, {
+    final bool? enabled,
+    final LogLevel? logLevel,
+    final bool? includeFileLineInHeader,
+    final Map<LogLevel, int>? stackMethodCount,
+    final Timestamp? timestamp,
+    final StackTraceParser? stackTraceParser,
+    final List<Handler>? handlers,
+    final bool? autoSinkBuffer,
+  }) {
+    if (pattern.isEmpty) {
+      throw ArgumentError.value(pattern, 'pattern', 'Pattern cannot be empty');
+    }
+
+    final config = LoggerConfig(
+      enabled: enabled,
+      logLevel: logLevel,
+      includeFileLineInHeader: includeFileLineInHeader,
+      stackMethodCount: stackMethodCount,
+      timestamp: timestamp,
+      stackTraceParser: stackTraceParser,
+      handlers: handlers,
+      autoSinkBuffer: autoSinkBuffer,
+    );
+
+    if (config.stackMethodCount != null) {
+      for (final smcEntry in config.stackMethodCount!.entries) {
+        if (smcEntry.value < 0) {
+          throw ArgumentError.value(
+            smcEntry.value,
+            'stackMethodCount[${smcEntry.key}]',
+            'Stack method count cannot be negative',
+          );
+        }
+      }
+    }
+    if (config.handlers != null && config.handlers!.isEmpty) {
+      throw ArgumentError.value(
+        config.handlers,
+        'handlers',
+        'Handlers list cannot be empty',
+      );
+    }
+
+    final regExp = _patternToRegExp(pattern);
+
+    _patternRules.add(
+      _PatternRule(
+        pattern: pattern,
+        regExp: regExp,
+        config: config,
+      ),
+    );
+
+    LoggerCache.clear();
+  }
+
+  static RegExp _patternToRegExp(final String pattern) {
+    final buffer = StringBuffer()..write('^');
+    for (var i = 0; i < pattern.length; i++) {
+      final char = pattern[i];
+      if (char == '*') {
+        buffer.write('.*');
+      } else if (char == '?') {
+        buffer.write('.');
+      } else if (const [
+        '.',
+        '+',
+        '^',
+        '\$',
+        '(',
+        ')',
+        '[',
+        ']',
+        '{',
+        '}',
+        '|',
+        '\\',
+      ].contains(char)) {
+        buffer.write('\\$char');
+      } else {
+        buffer.write(char);
+      }
+    }
+    buffer.write('\$');
+    return RegExp(buffer.toString(), caseSensitive: false);
+  }
+
   /// Exports the current configurations of all loggers registered.
   ///
   /// The returned object is a JSON-compatible map containing all configurations
@@ -858,8 +1003,16 @@ class Logger {
     for (final entry in _registry.entries) {
       configsMap[entry.key] = entry.value.toJson();
     }
+    final patternRulesList = <Map<String, dynamic>>[];
+    for (final rule in _patternRules) {
+      patternRulesList.add({
+        'pattern': rule.pattern,
+        'config': rule.config.toJson(),
+      });
+    }
     return <String, dynamic>{
       'registry': configsMap,
+      'patternRules': patternRulesList,
     };
   }
 
@@ -869,17 +1022,37 @@ class Logger {
   /// and invalidating cache keys.
   static void importConfig(final Map<String, dynamic> configData) {
     final registryMap = configData['registry'] as Map<dynamic, dynamic>?;
-    if (registryMap == null) {
-      return;
+    if (registryMap != null) {
+      for (final entry in registryMap.entries) {
+        final name = entry.key as String;
+        final configJson = entry.value as Map<dynamic, dynamic>;
+        final config =
+            LoggerConfig.fromJson(Map<String, dynamic>.from(configJson));
+        _registry[name] = config;
+      }
     }
-    for (final entry in registryMap.entries) {
-      final name = entry.key as String;
-      final configJson = entry.value as Map<dynamic, dynamic>;
-      final config =
-          LoggerConfig.fromJson(Map<String, dynamic>.from(configJson));
-      _registry[name] = config;
-      LoggerCache.invalidate(name);
+
+    final patternRulesList = configData['patternRules'] as List<dynamic>?;
+    if (patternRulesList != null) {
+      _patternRules.clear();
+      for (final ruleObj in patternRulesList) {
+        final ruleMap = ruleObj as Map<dynamic, dynamic>;
+        final pattern = ruleMap['pattern'] as String;
+        final configJson = ruleMap['config'] as Map<dynamic, dynamic>;
+        final config =
+            LoggerConfig.fromJson(Map<String, dynamic>.from(configJson));
+        final regExp = _patternToRegExp(pattern);
+        _patternRules.add(
+          _PatternRule(
+            pattern: pattern,
+            regExp: regExp,
+            config: config,
+          ),
+        );
+      }
     }
+
+    LoggerCache.clear();
   }
 
   /// Internal: Checks if a name is a descendant of parent.
@@ -1652,6 +1825,7 @@ class Logger {
     final name = loggerName == null ? 'global' : _normalizeName(loggerName);
     if (name == 'global') {
       _registry.clear();
+      _patternRules.clear();
       LoggerCache.clear();
     } else {
       LoggerCache.invalidate(name);

--- a/packages/logd/lib/src/stack_trace/callback_info.dart
+++ b/packages/logd/lib/src/stack_trace/callback_info.dart
@@ -9,6 +9,7 @@ class CallbackInfo {
     required this.filePath,
     required this.lineNumber,
     required this.fullMethod,
+    this.columnNumber,
   });
 
   /// The class name from the stack frame (empty if none).
@@ -23,11 +24,16 @@ class CallbackInfo {
   /// The line number in the file.
   final int lineNumber;
 
+  /// The column number in the file (nullable, not always present).
+  final int? columnNumber;
+
   /// The full method string from the stack (e.g., 'Class.method').
   final String fullMethod;
 
   @override
-  String toString() => '$className.$methodName ($filePath:$lineNumber)';
+  String toString() => columnNumber != null
+      ? '$className.$methodName ($filePath:$lineNumber:$columnNumber)'
+      : '$className.$methodName ($filePath:$lineNumber)';
 
   @override
   bool operator ==(final Object other) =>
@@ -38,6 +44,7 @@ class CallbackInfo {
           methodName == other.methodName &&
           filePath == other.filePath &&
           lineNumber == other.lineNumber &&
+          columnNumber == other.columnNumber &&
           fullMethod == other.fullMethod;
 
   @override
@@ -46,6 +53,7 @@ class CallbackInfo {
         methodName,
         filePath,
         lineNumber,
+        columnNumber,
         fullMethod,
       );
 }

--- a/packages/logd/lib/src/stack_trace/stack_trace_parser.dart
+++ b/packages/logd/lib/src/stack_trace/stack_trace_parser.dart
@@ -36,7 +36,7 @@ class StackTraceParser {
   // --- Regexes for various environments ---
 
   // VM Format: #0 Class.method (package:path/file.dart:25:7)
-  static final _vmRegex = RegExp(r'#\d+\s+(.+)\s+\((.+?):(\d+)(?::\d+)?\)');
+  static final _vmRegex = RegExp(r'#\d+\s+(.+)\s+\((.+?):(\d+)(?::(\d+))?\)');
 
   // Chrome Format 1: at Class.method (http://localhost:8080/main.dart.js:123:45)
   static final _chromeRegex1 =
@@ -125,6 +125,8 @@ class StackTraceParser {
       final fullMethod = match.group(1)!;
       final filePath = match.group(2)!;
       final lineNumber = int.parse(match.group(3)!);
+      final columnGroup = match.group(4);
+      final columnNumber = columnGroup != null ? int.parse(columnGroup) : null;
 
       final dotIndex = fullMethod.lastIndexOf('.');
       final className = dotIndex != -1 ? fullMethod.substring(0, dotIndex) : '';
@@ -136,6 +138,7 @@ class StackTraceParser {
         methodName: methodName,
         filePath: filePath,
         lineNumber: lineNumber,
+        columnNumber: columnNumber,
         fullMethod: fullMethod,
       );
     }
@@ -146,6 +149,7 @@ class StackTraceParser {
       final fullMethod = match.group(1)!;
       final filePath = match.group(2)!;
       final lineNumber = int.parse(match.group(3)!);
+      final columnNumber = int.parse(match.group(4)!);
 
       final dotIndex = fullMethod.lastIndexOf('.');
       final className = dotIndex != -1 ? fullMethod.substring(0, dotIndex) : '';
@@ -157,6 +161,7 @@ class StackTraceParser {
         methodName: methodName,
         filePath: filePath,
         lineNumber: lineNumber,
+        columnNumber: columnNumber,
         fullMethod: fullMethod,
       );
     }
@@ -167,6 +172,7 @@ class StackTraceParser {
       final fullMethod = match.group(1)!;
       final filePath = match.group(2)!;
       final lineNumber = int.parse(match.group(3)!);
+      final columnNumber = int.parse(match.group(4)!);
 
       final dotIndex = fullMethod.lastIndexOf('.');
       final className = dotIndex != -1 ? fullMethod.substring(0, dotIndex) : '';
@@ -178,6 +184,7 @@ class StackTraceParser {
         methodName: methodName,
         filePath: filePath,
         lineNumber: lineNumber,
+        columnNumber: columnNumber,
         fullMethod: fullMethod,
       );
     }
@@ -187,11 +194,13 @@ class StackTraceParser {
     if (match != null) {
       final filePath = match.group(1)!;
       final lineNumber = int.parse(match.group(2)!);
+      final columnNumber = int.parse(match.group(3)!);
       return CallbackInfo(
         className: '',
         methodName: '<anonymous>',
         filePath: filePath,
         lineNumber: lineNumber,
+        columnNumber: columnNumber,
         fullMethod: '<anonymous>',
       );
     }
@@ -201,11 +210,13 @@ class StackTraceParser {
     if (match != null) {
       final filePath = match.group(1)!;
       final lineNumber = int.parse(match.group(2)!);
+      final columnNumber = int.parse(match.group(3)!);
       return CallbackInfo(
         className: '',
         methodName: '<anonymous>',
         filePath: filePath,
         lineNumber: lineNumber,
+        columnNumber: columnNumber,
         fullMethod: '<anonymous>',
       );
     }

--- a/packages/logd/pubspec.yaml
+++ b/packages/logd/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logd
 description: Modular hierarchical logging for Dart and Flutter. Features modular pipeline processing, O(1) configuration resolution, and low‑overhead performance.
-version: 0.8.4
+version: 0.8.5
 repository: https://github.com/pooriaaskarim/logd
 homepage: https://github.com/pooriaaskarim/logd/tree/master/packages/logd
 documentation: https://github.com/pooriaaskarim/logd/tree/master/doc

--- a/packages/logd/test/core/stack_trace_parser_test.dart
+++ b/packages/logd/test/core/stack_trace_parser_test.dart
@@ -16,11 +16,13 @@ void main() {
       expect(result.caller!.methodName, equals('myMethod'));
       expect(result.caller!.filePath, equals('package:my_app/src/file.dart'));
       expect(result.caller!.lineNumber, equals(12));
+      expect(result.caller!.columnNumber, equals(34));
 
       expect(result.frames, hasLength(2));
       expect(result.frames[1].className, isEmpty);
       expect(result.frames[1].methodName, equals('otherFunction'));
       expect(result.frames[1].lineNumber, equals(56));
+      expect(result.frames[1].columnNumber, isNull);
     });
 
     test('should parse Chrome/V8 stack frames correctly', () {
@@ -40,10 +42,12 @@ Error
         equals('http://localhost:8080/main.dart.js'),
       );
       expect(result.caller!.lineNumber, equals(123));
+      expect(result.caller!.columnNumber, equals(45));
 
       expect(result.frames, hasLength(2));
       expect(result.frames[1].methodName, equals('<anonymous>'));
       expect(result.frames[1].lineNumber, equals(678));
+      expect(result.frames[1].columnNumber, equals(90));
     });
 
     test('should parse Firefox/Safari stack frames correctly', () {
@@ -62,10 +66,12 @@ http://localhost:8080/main.dart.js:678:90
         equals('http://localhost:8080/main.dart.js'),
       );
       expect(result.caller!.lineNumber, equals(123));
+      expect(result.caller!.columnNumber, equals(45));
 
       expect(result.frames, hasLength(2));
       expect(result.frames[1].methodName, equals('<anonymous>'));
       expect(result.frames[1].lineNumber, equals(678));
+      expect(result.frames[1].columnNumber, equals(90));
     });
 
     test(

--- a/packages/logd/test/logger/logger_serialization_test.dart
+++ b/packages/logd/test/logger/logger_serialization_test.dart
@@ -1,6 +1,5 @@
 import 'dart:isolate';
 import 'package:logd/logd.dart';
-import 'package:logd/src/logger/logger.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/logd/test/logger/logger_test.dart
+++ b/packages/logd/test/logger/logger_test.dart
@@ -501,6 +501,64 @@ void main() {
         isTrue,
       );
     });
+
+    group('Logger.configureMultiple()', () {
+      test('configures multiple loggers successfully', () {
+        Logger.configureMultiple({
+          'bulk1': const LoggerConfig(logLevel: LogLevel.warning),
+          'bulk2': const LoggerConfig(logLevel: LogLevel.error, enabled: false),
+        });
+
+        final l1 = Logger.get('bulk1');
+        final l2 = Logger.get('bulk2');
+
+        expect(l1.logLevel, equals(LogLevel.warning));
+        expect(l2.logLevel, equals(LogLevel.error));
+        expect(l2.enabled, isFalse);
+      });
+
+      test('validates inputs atomically', () {
+        expect(
+          () => Logger.configureMultiple({
+            'invalid1': const LoggerConfig(
+              stackMethodCount: {LogLevel.error: -5},
+            ),
+          }),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => Logger.configureMultiple({
+            'invalid2': const LoggerConfig(handlers: []),
+          }),
+          throwsArgumentError,
+        );
+      });
+
+      test('performs cache invalidation in a single pass', () {
+        Logger.configureMultiple({
+          'parent': const LoggerConfig(logLevel: LogLevel.info),
+          'parent.child': const LoggerConfig(),
+        });
+
+        final parent = Logger.get('parent');
+        final child = Logger.get('parent.child');
+
+        // Populate cache
+        expect(parent.logLevel, equals(LogLevel.info));
+        expect(child.logLevel, equals(LogLevel.info));
+
+        // Configure multiple in a batch
+        Logger.configureMultiple({
+          'parent': const LoggerConfig(logLevel: LogLevel.warning),
+          'parent.child': const LoggerConfig(logLevel: LogLevel.error),
+        });
+
+        // Cache should be updated
+        expect(parent.logLevel, equals(LogLevel.warning));
+        expect(child.logLevel, equals(LogLevel.error));
+      });
+    });
   });
 }
 

--- a/packages/logd/test/logger/logger_test.dart
+++ b/packages/logd/test/logger/logger_test.dart
@@ -669,6 +669,93 @@ void main() {
           expect(authImported.logLevel, equals(LogLevel.info));
         },
       );
+
+      test(
+        'emits warning when logger hierarchy depth exceeds maxHierarchyDepth',
+        () {
+          final logs = <String>[];
+          final previousMax = Logger.maxHierarchyDepth;
+          Logger.maxHierarchyDepth = 3;
+          try {
+            runZoned(
+              () {
+                // First access: should warn
+                Logger.get('a.b.c.d');
+                // Second access: should not warn again
+                Logger.get('a.b.c.d');
+                // Access different deep logger: should warn
+                Logger.get('x.y.z.w');
+              },
+              zoneSpecification: ZoneSpecification(
+                print: (final self, final parent, final zone, final line) {
+                  logs.add(line);
+                },
+              ),
+            );
+
+            expect(logs, hasLength(2));
+            expect(
+              logs[0],
+              contains(
+                'Logger hierarchy depth for "a.b.c.d" is 4, which exceeds '
+                'the maximum recommended threshold of 3',
+              ),
+            );
+            expect(
+              logs[1],
+              contains(
+                'Logger hierarchy depth for "x.y.z.w" is 4, which exceeds '
+                'the maximum recommended threshold of 3',
+              ),
+            );
+          } finally {
+            Logger.maxHierarchyDepth = previousMax;
+            Logger.reset();
+          }
+        },
+      );
+
+      test(
+        'resets warned deep loggers set when Logger.reset() is called',
+        () {
+          final logs = <String>[];
+          final previousMax = Logger.maxHierarchyDepth;
+          Logger.maxHierarchyDepth = 3;
+          try {
+            runZoned(
+              () {
+                Logger.get('a.b.c.d');
+              },
+              zoneSpecification: ZoneSpecification(
+                print: (final self, final parent, final zone, final line) {
+                  logs.add(line);
+                },
+              ),
+            );
+            expect(logs, hasLength(1));
+            logs.clear();
+
+            // Reset globally
+            Logger.reset();
+
+            runZoned(
+              () {
+                // Access again after reset: should warn again
+                Logger.get('a.b.c.d');
+              },
+              zoneSpecification: ZoneSpecification(
+                print: (final self, final parent, final zone, final line) {
+                  logs.add(line);
+                },
+              ),
+            );
+            expect(logs, hasLength(1));
+          } finally {
+            Logger.maxHierarchyDepth = previousMax;
+            Logger.reset();
+          }
+        },
+      );
     });
   });
 }

--- a/packages/logd/test/logger/logger_test.dart
+++ b/packages/logd/test/logger/logger_test.dart
@@ -756,6 +756,31 @@ void main() {
           }
         },
       );
+
+      test(
+        'disables hierarchy depth warning check when maxHierarchyDepth is <= 0',
+        () {
+          final logs = <String>[];
+          final previousMax = Logger.maxHierarchyDepth;
+          Logger.maxHierarchyDepth = 0;
+          try {
+            runZoned(
+              () {
+                Logger.get('a.b.c.d');
+              },
+              zoneSpecification: ZoneSpecification(
+                print: (final self, final parent, final zone, final line) {
+                  logs.add(line);
+                },
+              ),
+            );
+            expect(logs, isEmpty);
+          } finally {
+            Logger.maxHierarchyDepth = previousMax;
+            Logger.reset();
+          }
+        },
+      );
     });
   });
 }

--- a/packages/logd/test/logger/logger_test.dart
+++ b/packages/logd/test/logger/logger_test.dart
@@ -559,6 +559,117 @@ void main() {
         expect(child.logLevel, equals(LogLevel.error));
       });
     });
+
+    group('Logger.configurePattern', () {
+      setUp(() {
+        Logger.reset();
+      });
+
+      test('applies pattern configuration to matching loggers', () {
+        Logger.configurePattern('app.services.*', logLevel: LogLevel.info);
+
+        final auth = Logger.get('app.services.auth');
+        final db = Logger.get('app.services.db');
+        final ui = Logger.get('app.ui');
+
+        expect(auth.logLevel, equals(LogLevel.info));
+        expect(db.logLevel, equals(LogLevel.info));
+        expect(ui.logLevel, equals(LogLevel.debug)); // default
+      });
+
+      test('supports suffix matching via glob wildcard', () {
+        Logger.configurePattern('*.database', logLevel: LogLevel.warning);
+
+        final authDb = Logger.get('app.auth.database');
+        final billingDb = Logger.get('app.billing.database');
+        final dbHelper = Logger.get('app.db_helper');
+
+        expect(authDb.logLevel, equals(LogLevel.warning));
+        expect(billingDb.logLevel, equals(LogLevel.warning));
+        expect(dbHelper.logLevel, equals(LogLevel.debug));
+      });
+
+      test('validates input parameters correctly', () {
+        expect(
+          () => Logger.configurePattern('', logLevel: LogLevel.info),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => Logger.configurePattern(
+            '*.db',
+            stackMethodCount: {LogLevel.error: -1},
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => Logger.configurePattern('*.db', handlers: []),
+          throwsArgumentError,
+        );
+      });
+
+      test(
+        'newer pattern rules override older pattern rules when both match',
+        () {
+          Logger.configurePattern('app.*', logLevel: LogLevel.info);
+          Logger.configurePattern(
+            'app.services.*',
+            logLevel: LogLevel.warning,
+          );
+
+          final auth = Logger.get('app.services.auth');
+          final ui = Logger.get('app.ui');
+
+          expect(auth.logLevel, equals(LogLevel.warning));
+          expect(ui.logLevel, equals(LogLevel.info));
+        },
+      );
+
+      test('explicit configure overrides pattern rules', () {
+        Logger.configurePattern('app.services.*', logLevel: LogLevel.info);
+        Logger.configure('app.services.auth', logLevel: LogLevel.error);
+
+        final auth = Logger.get('app.services.auth');
+        final db = Logger.get('app.services.db');
+
+        expect(auth.logLevel, equals(LogLevel.error));
+        expect(db.logLevel, equals(LogLevel.info));
+      });
+
+      test('resets pattern rules when global reset is called', () {
+        Logger.configurePattern('app.services.*', logLevel: LogLevel.info);
+
+        final auth = Logger.get('app.services.auth');
+        expect(auth.logLevel, equals(LogLevel.info));
+
+        Logger.reset();
+
+        final authNew = Logger.get('app.services.auth');
+        expect(authNew.logLevel, equals(LogLevel.debug));
+      });
+
+      test(
+        'supports isolate export and import serialization of pattern rules',
+        () {
+          Logger.configurePattern('app.services.*', logLevel: LogLevel.info);
+
+          final auth = Logger.get('app.services.auth');
+          expect(auth.logLevel, equals(LogLevel.info));
+
+          final snapshot = Logger.exportConfig();
+          Logger.reset();
+
+          final authReset = Logger.get('app.services.auth');
+          expect(authReset.logLevel, equals(LogLevel.debug));
+
+          Logger.importConfig(snapshot);
+
+          final authImported = Logger.get('app.services.auth');
+          expect(authImported.logLevel, equals(LogLevel.info));
+        },
+      );
+    });
   });
 }
 


### PR DESCRIPTION
# Pull Request: Release v0.8.5

## Title
`release: v0.8.5 - Bulk Configuration, Wildcard Pattern Matching, Stack Trace Columns & Hierarchy Safeguards`

---

## Overview

This Pull Request merges the complete development cycle of `v0.8.5` from `dev` into `master`. This release introduces major developer experience, diagnostics, configuration efficiency, and performance safeguards to the `logd` logging framework.

### Summary of Changes

1. **Bulk Configuration API (`Logger.configureMultiple`)**:
   - Provides a single-pass API to apply multiple logger configurations atomically.
   - Replaces the $O(N^2)$ traversal costs of configuring $N$ loggers individually with a single batched invalidation pass (`LoggerCache.invalidateMultiple`), ensuring tree-walk operations are kept minimal.

2. **Wildcard & Pattern-Based Configuration (`Logger.configurePattern`)**:
   - Supports wildcards/glob patterns (e.g., `app.services.*` or `*.database`) to apply configs dynamically across hierarchies.
   - Integrates rule precedence where explicit configuration overrides patterns, and newer patterns take priority over older ones.
   - Fully serialized across isolates via `Logger.exportConfig` and `Logger.importConfig`.

3. **Stack Trace Column Preservation**:
   - Extends the parsing engine and `CallbackInfo` model to capture and retain `columnNumber` data across VM and Web environments (Chrome/Firefox/Safari) for precise source map tracking.

4. **Hierarchy Depth Safety Limits**:
   - Implemented warning thresholds on deep logger hierarchies (default >10 levels) to safeguard against stack overflows and performance degradation.
   - Allows threshold customization or complete bypass by setting `Logger.maxHierarchyDepth <= 0`.

5. **Magic Values Elimination**:
   - Refactored all hardcoded occurrences of `'global'` and magic frame skipping in `logger.dart` with named, class-private constants (`_globalLoggerName` and `_logMethodSkipFrames`).

---

## Detailed Component Diff

### 1. Configuration & Core API
*   [logger.dart](file:///home/ono/Projects/logd/packages/logd/lib/src/logger/logger.dart): Added `Logger.configureMultiple`, `Logger.configurePattern`, safety checks, and pattern resolution rules.
*   [logd.dart](file:///home/ono/Projects/logd/packages/logd/lib/logd.dart): Exported `LoggerConfig` to the public API.

### 2. Stack Trace Diagnostics
*   [callback_info.dart](file:///home/ono/Projects/logd/packages/logd/lib/src/stack_trace/callback_info.dart): Added nullable `columnNumber` field.
*   [stack_trace_parser.dart](file:///home/ono/Projects/logd/packages/logd/lib/src/stack_trace/stack_trace_parser.dart): Refactored regex capture groups to grab columns.

### 3. Documentation
*   [isolates.md](file:///home/ono/Projects/logd/doc/logger/isolates.md): Authored integration guide for coordinating configurations across isolates.
*   Updated roadmaps, readmes, and architecture specifications under `doc/` to reflect these features.

---

## Verification & Testing

### 1. Test Suite Results
All unit and integration tests are passing cleanly:
```text
All tests passed!
```
New test coverage was added specifically for:
*   `Logger.configureMultiple` atomicity and single-pass invalidation.
*   `Logger.configurePattern` hierarchy matching and serialization.
*   `maxHierarchyDepth` warnings and safety disabling.

### 2. Performance Verification (No Regression)
Comparing baseline benchmarks shows that the configuration overhead and processing times remain highly optimal:
*   `FullPipeline(RunTime)`: **2.78 µs** (consistent with the master branch baseline).
*   `ArenaFullPipeline(RunTime)`: **4.18 µs** (consistent with the master branch baseline).

---

## Diff Statistics
```text
 doc/logger/README.md                               |   7 +-
 doc/logger/architecture.md                         |  25 +-
 doc/logger/isolates.md                             | 192 ++++++
 doc/logger/philosophy.md                           |   5 +-
 doc/logger/roadmap.md                              |  23 +-
 doc/stack_trace/README.md                          |   3 +-
 doc/stack_trace/architecture.md                    |  27 +-
 doc/stack_trace/roadmap.md                         |  10 +-
 .../records/benchmark_20260629_111827.md           |  73 +++
 .../records/benchmark_20260630_115334.md           |  73 +++
 packages/logd/CHANGELOG.md                         |  23 +
 packages/logd/README.md                            |  38 +-
 packages/logd/lib/logd.dart                        |   2 +-
 packages/logd/lib/src/logger/logger.dart           | 642 +++++++++++++++------
 .../logd/lib/src/stack_trace/callback_info.dart    |  10 +-
 .../lib/src/stack_trace/stack_trace_parser.dart    |  13 +-
 packages/logd/pubspec.yaml                         |   2 +-
 .../logd/test/core/stack_trace_parser_test.dart    |   6 +
 .../test/logger/logger_serialization_test.dart     |   1 -
 packages/logd/test/logger/logger_test.dart         | 281 +++++++++
 20 files changed, 1246 insertions(+), 210 deletions(-)
```
