### PR TITLE
feat(linters): release logd_linters v0.1.2

### DIFF
--- a/.agents/knowledge/logd_linters/SESSIONS.md
+++ b/.agents/knowledge/logd_linters/SESSIONS.md
@@ -4,6 +4,29 @@
 
 ---
 
+## 2026-07-09 | v0.1.2 | Implemented 4 Quick-Fixes and Version Bump
+
+### What We Did
+- Implemented and verified the 4 remaining quick-fixes on the `v0.1.2` roadmap:
+  - `logd_metadata_set_duplicate` quick-fix (removes duplicate entries from metadata sets).
+  - `logd_missing_release_in_engine` quick-fix (wraps execute blocks in `try-finally` and releases document).
+  - `logd_decorator_not_immutable` & `logd_formatter_not_immutable` quick-fixes (adds `@immutable` and makes fields `final`).
+- Bumped package version in `pubspec.yaml` to `0.1.2`.
+- Documented changes in `CHANGELOG.md` and updated `STATUS.md`.
+- Ran full workspace-wide tests and verified custom_lint runs clean under the example project.
+
+---
+
+## 2026-07-09 | v0.1.1 | Validation and Live Release
+
+### What We Did
+- Verified package version `0.1.1` is live.
+- Successfully ran and verified package workspace tests (`dart test` in `packages/logd_linters` completed clean).
+- Validated AST rule behaviors on the integration test suite in `packages/logd_linters/example` using `dart run custom_lint` (zero unexpected issues/violations found).
+- Updated knowledge base `STATUS.md` to mark publishing as completed and pivot targets to the `v0.2.0` roadmap.
+
+---
+
 ## 2026-07-03 | v0.1.0-RC | Initial Rules Implementation & Integration Test Harness
 
 ### What We Did

--- a/.agents/knowledge/logd_linters/STATUS.md
+++ b/.agents/knowledge/logd_linters/STATUS.md
@@ -1,5 +1,5 @@
 # logd Linters — Status
-> Current as of: logd_linters v0.1.0-RC | Updated: 2026-07-08
+> Current as of: logd_linters v0.1.2 | Updated: 2026-07-09
 
 ---
 
@@ -7,9 +7,9 @@
 
 | Milestone | Status |
 |---|---|
-| v0.1.0 — 12 rules, 4 quick-fixes, full integration harness | ✅ Feature-complete, verified clean on core package |
-| v0.1.0 — Published to pub.dev | 🔲 Not yet done |
-| v0.2.0 — Remaining 8 quick-fixes | 🔲 Not started |
+| v0.1.0/v0.1.1 — 12 rules, 4 quick-fixes, full integration harness | ✅ Feature-complete, verified clean on core package |
+| v0.1.1 — Published to pub.dev | ✅ Published |
+| v0.1.2 — 4 additional quick-fixes (8/12 total) | ✅ Complete |
 | v0.2.0 — Multi-statement leak audits | 🔲 Not started |
 | Workspace-wide `custom_lint` enforcement | 🔲 Not started |
 
@@ -17,30 +17,11 @@
 
 ## Next Steps (Ordered)
 
-### 1. Publish v0.1.0 to pub.dev
-
-Run in `packages/logd_linters`:
-```bash
-dart analyze .
-dart format --output=none --set-exit-if-changed .
-dart pub publish --dry-run
-```
-Then publish `logd_linters` first, then update `logd` core `pubspec.yaml`:
-```diff
- logd_linters:
--  path: ../logd_linters
-+  ^0.1.0
-```
-Full checklist → see ARCHITECTURE.md § Publishing Checklist.
-
-### 2. v0.2.0 Quick-Fixes (after v0.1.0 is live)
-- `logd_metadata_set_duplicate` — remove duplicate items from set literals
-- `logd_missing_release_in_engine` — wrap body in `try-finally`, insert `releaseRecursive`
-- `logd_decorator_not_immutable` — prepend `@immutable`, convert non-final fields
-- `logd_formatter_not_immutable` — same as above
-
-### 3. Multi-Statement Checkout/Release Tracing
+### 1. v0.2.0 — Multi-Statement Checkout/Release Tracing
 Upgrade `CheckoutWithoutRelease` to trace checkouts that flow through helper variables across multiple statements, not just single-scope patterns.
+
+### 2. Workspace-Wide custom_lint Enforcement
+Enforce custom_lint plugin execution on CI and enable rules by default workspace-wide.
 
 ---
 
@@ -49,12 +30,12 @@ Upgrade `CheckoutWithoutRelease` to trace checkouts that flow through helper var
 | Rule | Group | Quick-Fix? |
 |---|---|---|
 | `logd_checkout_without_release` | A — Arena Lifecycle | 🔲 |
-| `logd_missing_release_in_engine` | A — Arena Lifecycle | 🔲 |
-| `logd_metadata_set_duplicate` | C — Consumer Usage | 🔲 |
-| `logd_decorator_not_immutable` | B — Purity & Boundaries | 🔲 |
-| `logd_formatter_not_immutable` | B — Purity & Boundaries | 🔲 |
+| `logd_missing_release_in_engine` | A — Arena Lifecycle | ✅ |
+| `logd_metadata_set_duplicate` | C — Consumer Usage | ✅ |
+| `logd_decorator_not_immutable` | B — Purity & Boundaries | ✅ |
+| `logd_formatter_not_immutable` | B — Purity & Boundaries | ✅ |
 | `logd_freeze_on_unconfigured_logger` | D — Inheritance Config | 🔲 |
-| *(+ 6 more)* | various | 4 of 12 have quick-fixes |
+| *(+ 6 more)* | various | 8 of 12 have quick-fixes |
 
 ---
 

--- a/packages/logd_linters/CHANGELOG.md
+++ b/packages/logd_linters/CHANGELOG.md
@@ -1,14 +1,27 @@
 # Changelog
 
-## 0.1.1
+## 0.1.2: Automation of Code-Style & Arena Lifecycle Rules (Quick-Fixes)
 
-- Populated package `LICENSE` file.
+This release focuses on improving the developer experience by introducing automated IDE quick-fixes for core validation warnings.
 
-## 0.1.0
+- ### Automated Quick-Fixes (DartFix)
+  - **Metadata Set Deduplication**: Added a fix for `logd_metadata_set_duplicate` that automatically removes duplicate entries from `metadata` set literals.
+  - **LogEngine Lifecycle Safety**: Added a fix for `logd_missing_release_in_engine` that automatically wraps `execute` method bodies in `try-finally` and invokes `releaseRecursive` in the `finally` block to protect the object pool.
+  - **Purity Enforcers (Immutability)**: Added fixes for `logd_decorator_not_immutable` and `logd_formatter_not_immutable` to automatically prepend the `@immutable` annotation (inserting the required `package:meta/meta.dart` import if missing) and convert mutable fields to `final`.
 
-- Initial release of `logd_linters`.
-- Added 12 custom rules grouped by concern:
-  - **Arena Lifecycle**: `logd_document_retained_across_cycles`, `logd_missing_release_in_engine`, `logd_checkout_without_release`.
-  - **Formatter/Decorator Purity**: `logd_formatter_performs_string_rendering`, `logd_decorator_not_immutable`, `logd_formatter_not_immutable`.
-  - **Consumer Usage**: `logd_avoid_print_sink_in_production`, `logd_logtag_use_bitmask`, `logd_log_buffer_not_sunk`, `logd_handler_missing_engine`, `logd_metadata_set_duplicate`.
-  - **Inheritance Configuration**: `logd_freeze_on_unconfigured_logger`.
+## 0.1.1: Licensing Cleanup
+
+This patch release completes the package packaging requirements.
+
+- ### Package Quality
+  - **License File**: Populated the package `LICENSE` file.
+
+## 0.1.0: Initial Custom Lint Release
+
+Initial release of `logd_linters`, establishing the AST-based validation suite for `logd`.
+
+- ### Rules Library (12 Rules, 4 Quick-Fixes)
+  - **Arena Lifecycle (Group A)**: Introduced rules preventing pool-leak and use-after-free bugs (`logd_document_retained_across_cycles`, `logd_missing_release_in_engine`, `logd_checkout_without_release`).
+  - **Formatter/Decorator Purity (Group B)**: Enforces physical-vs-semantic rendering boundaries (`logd_formatter_performs_string_rendering`, `logd_decorator_not_immutable`, `logd_formatter_not_immutable`).
+  - **Consumer Usage (Group C)**: Prevents engine misconfiguration, duplicate metadata arguments, and print sinks in production (`logd_avoid_print_sink_in_production`, `logd_logtag_use_bitmask`, `logd_log_buffer_not_sunk`, `logd_handler_missing_engine`, `logd_metadata_set_duplicate`).
+  - **Logger Config (Group D)**: Guards the logger inheritance system against unconfigured freeze attempts (`logd_freeze_on_unconfigured_logger`).

--- a/packages/logd_linters/lib/src/rules/arena/missing_release_in_engine.dart
+++ b/packages/logd_linters/lib/src/rules/arena/missing_release_in_engine.dart
@@ -91,4 +91,128 @@ class MissingReleaseInEngine extends DartLintRule {
       }
     });
   }
+
+  @override
+  List<Fix> getFixes() => [_WrapInTryFinallyFix()];
+}
+
+class _WrapInTryFinallyFix extends DartFix {
+  _WrapInTryFinallyFix();
+
+  @override
+  void run(
+    final CustomLintResolver resolver,
+    final ChangeReporter reporter,
+    final CustomLintContext context,
+    final AnalysisError analysisError,
+    final List<AnalysisError> others,
+  ) {
+    context.registry.addMethodDeclaration((final member) {
+      if (member.name.lexeme != 'execute') {
+        return;
+      }
+      if (!analysisError.sourceRange.intersects(member.name.sourceRange)) {
+        return;
+      }
+
+      final body = member.body;
+      if (body is! BlockFunctionBody) {
+        return;
+      }
+
+      final block = body.block;
+
+      // 1. Identify checkout statement and doc variable name
+      VariableDeclaration? checkoutVar;
+      Statement? checkoutStmt;
+      for (final stmt in block.statements) {
+        if (stmt is VariableDeclarationStatement) {
+          for (final variable in stmt.variables.variables) {
+            final init = variable.initializer;
+            if (init is MethodInvocation &&
+                init.methodName.name == 'checkoutDocument') {
+              checkoutVar = variable;
+              checkoutStmt = stmt;
+              break;
+            }
+          }
+        }
+        if (checkoutVar != null) {
+          break;
+        }
+      }
+
+      final docName = checkoutVar?.name.lexeme ?? 'doc';
+
+      // 2. Identify and separate statements
+      final beforeOrIncludingCheckout = <Statement>[];
+      final targetStatements = <Statement>[];
+      bool seenCheckout = false;
+
+      for (final stmt in block.statements) {
+        if (checkoutStmt != null) {
+          if (!seenCheckout) {
+            beforeOrIncludingCheckout.add(stmt);
+            if (stmt == checkoutStmt) {
+              seenCheckout = true;
+            }
+          } else {
+            if (_isReleaseCall(stmt, docName)) {
+              continue;
+            }
+            targetStatements.add(stmt);
+          }
+        } else {
+          if (_isReleaseCall(stmt, docName)) {
+            continue;
+          }
+          targetStatements.add(stmt);
+        }
+      }
+
+      reporter
+          .createChangeBuilder(
+        message: 'Wrap execute body in try-finally',
+        priority: 80,
+      )
+          .addDartFileEdit((final builder) {
+        final buffer = StringBuffer();
+        buffer.writeln('{');
+
+        // Write statements before/including checkout
+        for (final stmt in beforeOrIncludingCheckout) {
+          buffer.writeln('  ${stmt.toSource()}');
+        }
+
+        // Write try block
+        buffer.writeln('  try {');
+        for (final stmt in targetStatements) {
+          buffer.writeln('    ${stmt.toSource()}');
+        }
+        buffer.writeln('  } finally {');
+        buffer.writeln('    $docName.releaseRecursive(factory);');
+        buffer.writeln('  }');
+        buffer.write('}');
+
+        builder.addSimpleReplacement(body.sourceRange, buffer.toString());
+      });
+    });
+  }
+
+  bool _isReleaseCall(final Statement stmt, final String docName) {
+    if (stmt is ExpressionStatement) {
+      var expr = stmt.expression;
+      if (expr is AwaitExpression) {
+        expr = expr.expression;
+      }
+      if (expr is MethodInvocation &&
+          expr.methodName.name == 'releaseRecursive') {
+        final target = expr.target;
+        if (target is SimpleIdentifier && target.name == docName) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/packages/logd_linters/lib/src/rules/purity/decorator_not_immutable.dart
+++ b/packages/logd_linters/lib/src/rules/purity/decorator_not_immutable.dart
@@ -7,8 +7,10 @@
 /// Rule B2 — `logd_decorator_not_immutable`.
 library;
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import '../../utils/ast_helpers.dart';
@@ -75,6 +77,76 @@ class DecoratorNotImmutable extends DartLintRule {
       if (missingAnnotation || hasMutable) {
         reporter.atToken(classDecl.name, _code);
       }
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [_MakeDecoratorImmutableFix()];
+}
+
+class _MakeDecoratorImmutableFix extends DartFix {
+  _MakeDecoratorImmutableFix();
+
+  @override
+  void run(
+    final CustomLintResolver resolver,
+    final ChangeReporter reporter,
+    final CustomLintContext context,
+    final AnalysisError analysisError,
+    final List<AnalysisError> others,
+  ) {
+    context.registry.addClassDeclaration((final classDecl) {
+      if (analysisError.sourceRange.offset < classDecl.offset ||
+          analysisError.sourceRange.offset > classDecl.end) {
+        return;
+      }
+
+      reporter
+          .createChangeBuilder(
+        message: 'Make decorator class immutable',
+        priority: 80,
+      )
+          .addDartFileEdit((final builder) {
+        // 1. Add @immutable annotation
+        if (!hasImmutableAnnotation(classDecl)) {
+          final unit = classDecl.parent as CompilationUnit;
+          final hasMeta = unit.directives.whereType<ImportDirective>().any(
+              (final dir) => dir.uri.stringValue == 'package:meta/meta.dart');
+
+          if (!hasMeta) {
+            final firstDirective =
+                unit.directives.isEmpty ? null : unit.directives.first;
+            final insertOffset = firstDirective?.offset ?? 0;
+            builder.addSimpleInsertion(
+                insertOffset, "import 'package:meta/meta.dart';\n");
+          }
+
+          final insertOffset = classDecl.metadata.isNotEmpty
+              ? classDecl.metadata.first.offset
+              : classDecl.classKeyword.offset;
+          builder.addSimpleInsertion(insertOffset, '@immutable\n');
+        }
+
+        // 2. Make non-static mutable fields final
+        for (final member in classDecl.members) {
+          if (member is FieldDeclaration && !member.isStatic) {
+            final fields = member.fields;
+            if (!fields.isFinal && !fields.isConst) {
+              final keyword = fields.keyword;
+              if (keyword != null && keyword.lexeme == 'var') {
+                builder.addSimpleReplacement(
+                  SourceRange(keyword.offset, keyword.length),
+                  'final',
+                );
+              } else if (keyword == null) {
+                final insertOffset =
+                    fields.type?.offset ?? fields.variables.first.offset;
+                builder.addSimpleInsertion(insertOffset, 'final ');
+              }
+            }
+          }
+        }
+      });
     });
   }
 }

--- a/packages/logd_linters/lib/src/rules/purity/formatter_not_immutable.dart
+++ b/packages/logd_linters/lib/src/rules/purity/formatter_not_immutable.dart
@@ -7,8 +7,10 @@
 /// Rule B3 — `logd_formatter_not_immutable`.
 library;
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import '../../utils/ast_helpers.dart';
@@ -89,6 +91,76 @@ class FormatterNotImmutable extends DartLintRule {
       if (missingAnnotation || hasMutable) {
         reporter.atToken(classDecl.name, _code);
       }
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [_MakeFormatterImmutableFix()];
+}
+
+class _MakeFormatterImmutableFix extends DartFix {
+  _MakeFormatterImmutableFix();
+
+  @override
+  void run(
+    final CustomLintResolver resolver,
+    final ChangeReporter reporter,
+    final CustomLintContext context,
+    final AnalysisError analysisError,
+    final List<AnalysisError> others,
+  ) {
+    context.registry.addClassDeclaration((final classDecl) {
+      if (analysisError.sourceRange.offset < classDecl.offset ||
+          analysisError.sourceRange.offset > classDecl.end) {
+        return;
+      }
+
+      reporter
+          .createChangeBuilder(
+        message: 'Make formatter class immutable',
+        priority: 80,
+      )
+          .addDartFileEdit((final builder) {
+        // 1. Add @immutable annotation
+        if (!hasImmutableAnnotation(classDecl)) {
+          final unit = classDecl.parent as CompilationUnit;
+          final hasMeta = unit.directives.whereType<ImportDirective>().any(
+              (final dir) => dir.uri.stringValue == 'package:meta/meta.dart');
+
+          if (!hasMeta) {
+            final firstDirective =
+                unit.directives.isEmpty ? null : unit.directives.first;
+            final insertOffset = firstDirective?.offset ?? 0;
+            builder.addSimpleInsertion(
+                insertOffset, "import 'package:meta/meta.dart';\n");
+          }
+
+          final insertOffset = classDecl.metadata.isNotEmpty
+              ? classDecl.metadata.first.offset
+              : classDecl.classKeyword.offset;
+          builder.addSimpleInsertion(insertOffset, '@immutable\n');
+        }
+
+        // 2. Make non-static mutable fields final
+        for (final member in classDecl.members) {
+          if (member is FieldDeclaration && !member.isStatic) {
+            final fields = member.fields;
+            if (!fields.isFinal && !fields.isConst) {
+              final keyword = fields.keyword;
+              if (keyword != null && keyword.lexeme == 'var') {
+                builder.addSimpleReplacement(
+                  SourceRange(keyword.offset, keyword.length),
+                  'final',
+                );
+              } else if (keyword == null) {
+                final insertOffset =
+                    fields.type?.offset ?? fields.variables.first.offset;
+                builder.addSimpleInsertion(insertOffset, 'final ');
+              }
+            }
+          }
+        }
+      });
     });
   }
 }

--- a/packages/logd_linters/lib/src/rules/usage/metadata_set_duplicate.dart
+++ b/packages/logd_linters/lib/src/rules/usage/metadata_set_duplicate.dart
@@ -10,6 +10,7 @@ library;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import '../../utils/type_checkers.dart';
@@ -84,9 +85,12 @@ class MetadataSetDuplicate extends DartLintRule {
     });
   }
 
+  @override
+  List<Fix> getFixes() => [_RemoveDuplicateMetadataFix()];
+
   /// Returns the LogMetadata enum constant name for [expr], or null if [expr]
   /// is not a LogMetadata reference.
-  String? _logMetadataName(final Expression expr) {
+  static String? _logMetadataName(final Expression expr) {
     if (expr is PrefixedIdentifier) {
       if (expr.prefix.name == 'LogMetadata') {
         return expr.identifier.name;
@@ -106,5 +110,65 @@ class MetadataSetDuplicate extends DartLintRule {
       }
     }
     return null;
+  }
+}
+
+class _RemoveDuplicateMetadataFix extends DartFix {
+  _RemoveDuplicateMetadataFix();
+
+  @override
+  void run(
+    final CustomLintResolver resolver,
+    final ChangeReporter reporter,
+    final CustomLintContext context,
+    final AnalysisError analysisError,
+    final List<AnalysisError> others,
+  ) {
+    context.registry.addSetOrMapLiteral((final node) {
+      if (!analysisError.sourceRange.intersects(node.sourceRange)) {
+        return;
+      }
+
+      final seen = <String>{};
+      Expression? duplicateElement;
+      Expression? previousElement;
+
+      for (final element in node.elements) {
+        if (element is! Expression) {
+          continue;
+        }
+        final name = MetadataSetDuplicate._logMetadataName(element);
+        if (name == null) {
+          continue;
+        }
+        if (!seen.add(name)) {
+          if (analysisError.sourceRange.intersects(element.sourceRange)) {
+            duplicateElement = element;
+            break;
+          }
+        }
+        if (duplicateElement == null) {
+          previousElement = element;
+        }
+      }
+
+      final dup = duplicateElement;
+      final prev = previousElement;
+      if (dup != null && prev != null) {
+        reporter
+            .createChangeBuilder(
+          message: 'Remove duplicate LogMetadata entry',
+          priority: 80,
+        )
+            .addDartFileEdit((final builder) {
+          builder.addDeletion(
+            SourceRange(
+              prev.end,
+              dup.end - prev.end,
+            ),
+          );
+        });
+      }
+    });
   }
 }

--- a/packages/logd_linters/pubspec.yaml
+++ b/packages/logd_linters/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Custom lint rules for the logd logging library. Surfaces arena lifecycle
   constraints, formatter/decorator purity invariants, and consumer usage
   best-practices as static analysis warnings with IDE quick-fixes.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/pooriaaskarim/logd
 homepage: https://github.com/pooriaaskarim/logd/tree/master/packages/logd_linters
 topics:


### PR DESCRIPTION
## Overview
This PR prepares and releases version `0.1.2` of the `logd_linters` package. It introduces 4 new automated IDE quick-fixes for existing rules, bumps the package version, and updates the changelog.

## Changes

### 1. Automated Quick-Fixes (DartFix)
* **Metadata Set Deduplication**: Added a fix for `logd_metadata_set_duplicate` that automatically removes duplicate entries from `metadata` set literals.
* **LogEngine Lifecycle Safety**: Added a fix for `logd_missing_release_in_engine` that automatically wraps `execute` method bodies in `try-finally` and invokes `releaseRecursive` in the `finally` block to protect the object pool.
* **Purity Enforcers (Immutability)**: Added fixes for `logd_decorator_not_immutable` and `logd_formatter_not_immutable` to automatically prepend the `@immutable` annotation (inserting the required `package:meta/meta.dart` import if missing) and convert mutable fields to `final`.

### 2. Versioning & Documentation
* Bumped package version to `0.1.2` in `pubspec.yaml`.
* Standardized `CHANGELOG.md` design to match the rich visual category structure of the core `logd` package.
* Updated `STATUS.md` and `SESSIONS.md` to reflect `v0.1.2` milestones as complete.

## Verification
* Ran `dart test` in `packages/logd_linters` (passed).
* Ran `dart run custom_lint --fix` in `packages/logd_linters/example` to verify quick-fix applications (passed and clean).
* Ran workspace-wide `dart analyze .` (passed with 0 warnings/errors).
