### PR TITLE
docs: backfill knowledge base, update stack trace guide, and calibrate v0.10.x roadmap

### DIFF
--- a/.agents/knowledge/logd_core/SESSIONS.md
+++ b/.agents/knowledge/logd_core/SESSIONS.md
@@ -4,6 +4,81 @@
 
 ---
 
+## 2026-08-19 | v0.9.4 | Hot-Path Origin Bypass & Ambient Structured Context (MDC)
+
+### What We Did
+- **Origin Bypass (`includeOrigin: false`)**: Bypassed `StackTrace.current` VM unwinding and regex parsing when caller origin is not needed and `stackMethodCount == 0`, delivering ~5x throughput speedup (~2.38 µs/log). Preserved explicit stack traces and frame count collections.
+- **Ambient Structured Context (`LogContext.run` / MDC)**: Implemented Zone-based ambient context propagation across synchronous execution and async `await` chains without threading maps through method parameters.
+- **Scope Hierarchy & Fast Path**: Scopes merge hierarchically (inner overrides outer for scope duration). `LogContext.merge()` performs 0 heap allocations when no context is active.
+- **Formatter Integration**: Formatter suite (`StructuredFormatter`, `PlainFormatter`, `JsonFormatter`, `ToonFormatter`) and `ContextFilter` seamlessly render and filter `LogEntry.context`.
+- **Validation & Benchmarks**: Added `lazy_stack_benchmark.dart`, `log_context_benchmark.dart`, `origin_bypass_demo.dart`, `ambient_context_demo.dart`, and full test suites with 100% pass rate across 2,513 tests.
+- **Documentation**: Updated `README.md`, `CHANGELOG.md`, `doc/logger/architecture.md`, `doc/logger/README.md`, and `doc/stack_trace/architecture.md`.
+
+### Key Decisions
+- `context` is treated as core payload data (like `message`, `error`, `stackTrace`), rather than suppressible envelope metadata in `LogMetadata` (`timestamp`, `logger`, `origin`). This maintains backward compatibility and prevents silent data drops.
+
+---
+
+## 2026-08-05 | v0.9.3 | Target Handlers & Dual-Mode `.async()` Offloading
+
+### What We Did
+- **Pre-Wired `{Target}Handler` Architecture (ADR-006)**: Replaced multi-stage manual pipeline wiring with 8 strongly-typed convenience subclasses: `ConsoleHandler`, `HtmlFileHandler`, `JsonFileHandler`, `PlainFileHandler`, `ToonFileHandler`, `MarkdownFileHandler`, `HttpDashboardHandler`, `MemoryHandler`.
+- **Dual-Mode `.async()` Factory Constructors**: Added `.async()` constructors across all 6 output-bound handlers, automatically offloading formatting, decoration, and physical I/O to background worker isolates (~15 µs return).
+- **Safety by Design**: Kept `MemoryHandler` (in-process heap) and `HttpDashboardHandler` (local socket server) strictly synchronous in-process to avoid cross-isolate state disconnects.
+- **Modular Entry Point**: Created `package:logd/advanced.dart` exposing low-level engine and isolate internals (`AsyncHandler`, `ArenaEngine`, `NativeEngine`, `IsolateSink`, `LogEngine`) for engine authors, simplifying the primary `package:logd/logd.dart` export surface.
+
+---
+
+## 2026-08-01 | v0.9.2 | Theme Isolate State Preservation & SQLite Satellite Package
+
+### What We Did
+- **Theme Brightness Transport**: Fixed theme brightness state loss across multi-isolate boundaries in `LoggerSerializationRegistry`. Preserved `LogBrightness` state (`dark` vs `light`) across `AsyncHandler` and `IsolateSink` transfers.
+- **High-Contrast Light Theme**: Added WCAG AA-compliant high-contrast amber/red/green color palette mappings to `LogColorScheme.lightScheme` and `DefaultHtmlStylesheet`.
+- **Deep Hierarchy Safeguards**: Verified 12-level deep logger tree configuration resolution completes in < 50 µs/lookup; enforced `Logger.maxHierarchyDepth` safety limit warnings.
+- **Ecosystem Expansion**: Launched [`logd_sqlite`](https://pub.dev/packages/logd_sqlite) satellite package (v0.1.0) for high-performance SQLite WAL log persistence.
+
+---
+
+## 2026-07-28 | v0.9.1 | Native TOON Format & Protocol Auto-Detect Encoders
+
+### What We Did
+- **Tree-Oriented Object Notation (TOON)**: Implemented native `ToonFormatter` for semantic IR and `ToonEncoder` for string/ANSI rendering; integrated with live HTTP dashboard viewer; authored `doc/toon_spec.md`.
+- **Protocol Auto-Detect Encoders (`AutoEncoder`)**: Standardized `'logd.encoder'` metadata contract, enabling default sinks (`ConsoleSink`, `FileSink`, `HttpSink`, `SocketSink`) to auto-delegate to matching physical encoders.
+- **Self-Declaring Wrapping Strategies**: Added `requiredStrategy` getter to `LogEncoder`, allowing `EncodingSink` to default to the encoder's minimum required wrapping strategy.
+- **In-Memory Ring Buffer (`MemorySink`)**: Added bounded `MemorySink<T>` and capacity capping (`maxEntries`) on `LogBuffer`.
+- **Stack Trace Symbol Hooks**: Added `@experimental` `SymbolResolver` hook to `StackTraceParser` for custom symbol demangling and deobfuscation.
+- **ADRs 002–005**: Authored architecture decision records covering cache invalidation, sparse storage, unmodifiable collections, and internal logger contracts.
+
+---
+
+## 2026-07-22 | v0.9.0 | Core API Stabilization & Semver Contract (Phase 1)
+
+### What We Did
+- **API Stabilization**: Audited all public exports; decorated low-level FFI/native components with `@experimental`; froze `LogFormatter`, `LogDecorator`, `LogSink`, and `Handler` as stable extension points.
+- **Semver Specification**: Published `doc/semver_contract.md` defining stability tiers and breaking change policies.
+- **Unified Theme Architecture**: Consolidated semantic color palettes into `LogColorScheme` (5 levels) and visual styling into `LogStyle`; standardized `StyleDecorator` as the single source of truth for attaching theme metadata to `document.metadata['logd.theme']`.
+- **Extracted `HtmlStylesheet`**: Decoupled CSS/JS generation from `HtmlEncoder` into interchangeable `HtmlStylesheet` interface.
+
+---
+
+## 2026-07-18 | v0.8.9 | Web Source Mapping & Polymorphic Serialization
+
+### What We Did
+- **Web Source Mapping (Phase B)**: Enabled translation of Chrome, Firefox, and Safari stack traces back to original Dart source coordinates and deobfuscated method names via `.js.map` source maps.
+- **Polymorphic Serialization Fix**: Fixed a bug where custom log sinks or filters registered in multi-isolate environments failed to serialize due to generic type erasure.
+- **Timezone Parameter Hardening**: Hardened named timezone parameter parsing with input validation.
+
+---
+
+## 2026-07-12 | v0.8.8 | Async Isolate Offloading & Live HttpServer Dashboard
+
+### What We Did
+- **Isolate Offloading (`AsyncHandler`)**: Overhauled background worker isolate offloading with reusable `IsolateWorker` lifecycle manager.
+- **Embedded Dashboard (`HttpServerSink`)**: Added loopback HTTP dashboard server with WebSocket upgrade for real-time live log telemetry.
+- **Lifecycle Guarantees**: Added public `Future<void> dispose()` contract to `Handler` base class and `ready` startup completers.
+
+---
+
 ## 2026-07-08 | v0.8.7 | Core Stabilization & Concurrency Hardening
 
 ### What We Did

--- a/.agents/knowledge/logd_core/STATUS.md
+++ b/.agents/knowledge/logd_core/STATUS.md
@@ -1,5 +1,5 @@
 # logd Core — Status
-> Current version: v0.8.7 | Updated: 2026-07-08
+> Current version: v0.9.4 | Updated: 2026-08-19
 
 ---
 
@@ -8,13 +8,18 @@
 | Area | State |
 |---|---|
 | Pipeline Architecture (Formatter → Decorator → TerminalLayout → Encoder → Sink) | ✅ Stable |
+| Target Handlers Architecture (ADR-006: `ConsoleHandler`, `JsonFileHandler`, etc.) | ✅ Stable since v0.9.3 |
+| Dual-Mode `.async()` Background Isolate Pipelines | ✅ Stable since v0.9.3 |
+| Power-User Entry Point (`package:logd/advanced.dart`) | ✅ Stable since v0.9.3 |
 | Logger Hierarchy & Inheritance (`freezeInheritance`, `unfreezeInheritance`) | ✅ Stable since v0.8.2 |
+| Ambient Structured Context (`LogContext.run` / MDC) | ✅ Stable since v0.9.4 |
+| Hot-Path Caller Origin Bypass (`includeOrigin: false`) | ✅ Stable since v0.9.4 |
 | Arena / Object Pooling | ✅ Stable. LIFO pool, Finalizer leak detection |
 | `NativeEngine` / Binary IR | ✅ Stable. Streaming + Object mode |
 | `LogPipelineFactory` injection | ✅ Stable since factory injection refactor |
 | `LoggerConfig` immutability + `copyWith` | ✅ Stable since v0.8.4 |
 | `Logger.configureMultiple` + batched invalidation | ✅ Stable since v0.8.4 dev |
-| `LoggerSerializationRegistry` (cross-isolate transport) | ✅ Stable since v0.8.4 |
+| `LoggerSerializationRegistry` (cross-isolate transport) | ⚠️ Static snapshot only (see `logd_isolate_model/` for v1.0 architecture) |
 | `package:logd/testing.dart` (`CaptureSink`, `TestLogger`, `hasLog`) | ✅ Stable since v0.8.4 |
 | Flutter SDK decoupled (pure Dart CLI/VM) | ✅ Stable since v0.8.4 |
 | Web compilation (zero `dart:ffi`/`dart:io` in entry point) | ✅ Fixed in v0.8.6 |
@@ -25,7 +30,18 @@
 
 ---
 
-## What Was Just Done (v0.8.7)
+## What Was Just Done (v0.9.4)
+
+**Hot-Path Optimization & Stack Bypass:**
+- Added `includeOrigin` to `LoggerConfig` and `Logger.configure*` (defaults to `true`).
+- When `includeOrigin: false` and `stackMethodCount[level] == 0` without explicit `stackTrace`, completely skips `StackTrace.current` VM unwinding and regex parsing (~5x throughput gain, ~2.38 µs/log).
+- Preserves explicit `stackTrace` and frame collection via `stackMethodCount`.
+
+**Ambient Structured Context (MDC):**
+- Introduced `LogContext.run()` using Dart `Zone`s to propagate ambient structured key-value pairs across synchronous and asynchronous `await` call stacks.
+- Zero-cost fast path: `LogContext.merge()` allocates 0 bytes when no context is present.
+- Supports nested scope inheritance, shadowing, and call-site overrides (`logger.info('msg', context: {...})`).
+- Integrated into `StructuredFormatter`, `PlainFormatter`, `JsonFormatter`, `ToonFormatter`, and `ContextFilter`.
 
 **Concurrency & Arena:**
 - Thread waiter queue in `Arena` replaced single-slot waiter → no more race conditions under async saturation

--- a/.agents/knowledge/logd_isolate_model/ARCHITECTURE.md
+++ b/.agents/knowledge/logd_isolate_model/ARCHITECTURE.md
@@ -1,0 +1,74 @@
+# logd Isolate Model — Architecture & Structural Analysis
+> Author: System Architecture Analysis | Date: 2026-08-19
+
+---
+
+## 1. Executive Summary & The Structural Gap
+
+`logd` was originally designed as a high-throughput, in-process, allocation-minimized logging engine. Its internal components (`Logger` namespace tree, `LoggerCache`, `Arena` LIFO pool, `LoggerSerializationRegistry`, `LogContext`) are instantiated as **process-local singletons within an isolate's private heap**.
+
+When developers introduce multi-isolate architectures (such as `Isolate.spawn()`, Flutter background workers, or Dart Frog server clusters), each isolate possesses completely distinct instances of these objects:
+- `Logger.get('app.database')` in Isolate A and `Logger.get('app.database')` in Isolate B are entirely independent objects.
+- `Logger.configure()` executed in the main isolate has zero effect on background workers unless manually serialized and passed via `SendPort`.
+- `LogContext.run({'requestId': 'req-123'}, ...)` relies on Dart `Zone`s, which are strictly isolated per thread/isolate and do not propagate across `Isolate.spawn()` boundaries.
+
+Attempting to solve this with a lightweight pub/sub bus (`LogdIsolateHub`) is an **immature patch on top of patches**: it introduces race conditions, partial cache invalidation hazards, and message ordering ambiguities without resolving the underlying architectural ambiguity.
+
+---
+
+## 2. Core Architectural Challenges
+
+### Challenge A: Configuration Authority & Drift
+In an isolate hierarchy, who is the source of truth for logger configuration?
+1. **Centralized (Primary-Owned)**: The primary isolate is the single authority. All background isolates are read-only mirrors. If a worker calls `Logger.configure()`, it throws an error or forwards a mutation request to the primary.
+2. **Decentralized / Autonomous**: Each isolate can customize its own log level (e.g. background data worker logs at `LogLevel.warn`, primary UI logs at `LogLevel.debug`), with optional fallback inheritance from a shared bootstrap config.
+
+Currently, `logd` has neither: workers silently mutate their local config, causing silent divergence between isolates with no notification or deterministic reconciliation.
+
+### Challenge B: Memory Boundaries vs. Ambient MDC Propagation
+`LogContext` uses Dart `Zone` values for zero-allocation propagation through synchronous and asynchronous execution paths. However:
+- Zones are tied to the local event loop of an isolate.
+- Background workers spawned to process CPU-intensive tasks lose all active ambient MDC metadata unless explicitly packed into the worker input data and manually unpacked via `LogContext.run(...)` inside the isolate entrypoint.
+
+A principled multi-isolate logging architecture must provide ergonomic hooks (e.g. `IsolateRunner` wrappers or `LogContext.wrapCallback`) to serialize and restore ambient context across isolate boundaries.
+
+### Challenge C: In-Flight Crash Safety & Packet Loss
+`NativeIsolateSink` provides auto-recovery (respawning workers after a 2-second backoff if they crash). However:
+- Packets queued in the dying isolate's in-memory mailbox are permanently lost.
+- There is no backpressure or acknowledgment handshake between the producer isolate and consumer sink isolate.
+
+### Challenge D: Multi-Isolate Trace & Span Correlation
+In enterprise multi-isolate topologies:
+- An HTTP request enters the primary isolate (`traceId: T1`, `spanId: S1`).
+- Heavy JSON parsing or image compression is dispatched to Worker Isolate 3 (`spanId: S2`, `parentSpanId: S1`).
+- Log lines emitted by Worker 3 have no intrinsic correlation to `T1` unless manual log parameters are threaded.
+
+---
+
+## 3. Principled Multi-Isolate Architecture Requirements (v0.10.x Vision)
+
+A mature multi-isolate architecture for `logd` (targeting the `v0.10.x` series ahead of `v1.0.0`) requires:
+
+```mermaid
+graph TD
+    subgraph Primary Isolate
+        PL[Logger Hierarchy] --> PC[Config Authority]
+        PL --> PLC[LogContext Scope]
+        PC -- "Topology Broadcast (Binary IR)" --> IH[Isolate Channel / Port]
+    end
+
+    subgraph Background Worker Isolate
+        IH -- "Config Mirror Sync" --> WC[Worker Config Mirror]
+        WLC[Worker LogContext] --> WL[Worker Logger]
+        WC --> WL
+        WL -- "Binary IR Log Stream" --> SP[SendPort Queue]
+    end
+
+    SP --> CS[Unified Central Log Pipeline]
+    CS --> FS[FileSink / ConsoleSink / NetworkSink]
+```
+
+1. **Explicit Topology Declaration**: Formally register isolate roles (`LogdIsolateRole.primary`, `LogdIsolateRole.worker`) during initialization.
+2. **Deterministic Configuration Protocol**: Binary-encoded, version-stamped configuration messages broadcast from the authority isolate to worker mirrors.
+3. **Cross-Isolate Context Bridges**: Standard helpers to wrap isolate entrypoints with ambient context serialization and restoration.
+4. **Unified Ingestion Stream**: Worker isolates forward structured binary packets to a dedicated logging coordinator isolate or the primary sink pipeline to prevent interleaving and lock contention on physical I/O resources (files, sockets).

--- a/.agents/knowledge/logd_isolate_model/OPEN_QUESTIONS.md
+++ b/.agents/knowledge/logd_isolate_model/OPEN_QUESTIONS.md
@@ -1,0 +1,49 @@
+# logd Isolate Model — Open Design Questions
+> Status: Unresolved / Queued for v0.10.x Research | Created: 2026-08-19
+
+---
+
+## Decision Register (Ordered by Dependency)
+
+### 1. Topology Declaration Model
+- **Question**: Should `logd` require explicit initialization of isolate topology, or support ad-hoc isolate participation?
+- **Options**:
+  - A. *Explicit Roles*: `LogdIsolate.init(role: LogdIsolateRole.primary)` and `LogdIsolate.connect(primaryPort)` on worker startup.
+  - B. *Implicit Discovery*: Auto-detect main isolate via Zone tokens or static registry.
+- **Dependency**: Must be decided before any configuration protocol is implemented.
+
+---
+
+### 2. Configuration Authority & Conflict Resolution
+- **Question**: Who is the authoritative source of truth for `LoggerConfig` updates?
+- **Options**:
+  - A. *Strict Primary Authority*: Only the primary isolate may call `Logger.configure()`. Worker calls throw `UnsupportedError` or silently request primary mutation.
+  - B. *Hierarchical Override*: Primary broadcast sets baseline; workers may establish local override namespaces (e.g. `worker.compute.*`).
+  - C. *Multi-Master Distributed*: Any isolate can update config, synchronized via versioned vector clocks. (High complexity).
+- **Dependency**: Depends on Decision 1 (Topology Model).
+
+---
+
+### 3. Context & MDC Isolate Boundary Crossing
+- **Question**: How should ambient `LogContext` values cross `Isolate.spawn()` boundaries?
+- **Options**:
+  - A. *Explicit Envelope Packaging*: Provide `LogContext.capture()` / `LogContext.runWith(capturedContext, body)`.
+  - B. *Isolate Runner Helpers*: Provide `LogdIsolate.run(workerFunction, inputData)` which automatically captures ambient MDC and unpacks it in the worker isolate.
+- **Dependency**: Independent, can be designed in parallel with Decision 2.
+
+---
+
+### 4. Entry Ingestion Architecture
+- **Question**: Should all isolates log directly to their own sinks, or stream binary log packets to a centralized coordinator sink?
+- **Options**:
+  - A. *Centralized Coordinator*: All workers pipe binary IR to the primary/logging isolate via `SendPort`. Only one isolate touches files/terminals/sockets. Eliminates file lock contention and interleaving.
+  - B. *Independent Pipelines*: Each isolate has its own sink stack.
+- **Trade-offs**: Centralized eliminates file locking and formatting duplicate work, but increases GC / SendPort transfer overhead under ultra-high throughput.
+
+---
+
+### 5. Trace / Span Correlation Standard
+- **Question**: Should `logd` implement a first-class trace/span context data structure or provide generic OpenTelemetry-compatible map hooks?
+- **Options**:
+  - A. Generic `LogContext` keys (`traceId`, `spanId`, `parentSpanId`) with standard convention.
+  - B. Native `LogSpan` / `LogTrace` primitives in semantic IR.

--- a/.agents/knowledge/logd_isolate_model/SESSIONS.md
+++ b/.agents/knowledge/logd_isolate_model/SESSIONS.md
@@ -1,0 +1,19 @@
+# logd Isolate Model — Session Log
+> Append-only. Each entry records what was attempted, what broke, and what was learned.
+> Never edit past entries. Add new entries at the top.
+
+---
+
+## 2026-08-19 | v0.9.4 | Strategic Architectural Pivot
+
+### What We Did
+- Conducted structural audit of `logd`'s multi-isolate support following the implementation of ambient `LogContext`.
+- Identified that `logd`'s Logger hierarchy, configuration registry, and context propagation are process-local singleton concepts that exist independently in each isolate's heap.
+- Formally rejected the proposed `LogdIsolateHub` point-patch (a dynamic pub/sub message bus) as an immature band-aid that layers complexity over an unprincipled isolate model.
+- Created the dedicated `logd_isolate_model` knowledge item to capture architectural gaps, structural challenges, and open design questions for a comprehensive v1.0 multi-isolate architecture.
+- Updated product roadmap: replaced `LogdIsolateHub` with **Multi-Isolate Architecture Design (v0.10.x track)**.
+- Established that `v0.10.x` is the appropriate pathway to iterate on the multi-isolate semantic model with full design freedom before making a `v1.0.0` stability commitment.
+
+### Key Insights
+- Zones used by `LogContext.run()` are isolate-local; ambient context cannot cross isolate boundaries without explicit serialization.
+- Multi-isolate support cannot be solved piecemeal; it requires formalizing isolate topology, configuration authority, ambient context bridging, and centralized vs. distributed entry ingestion.

--- a/.agents/knowledge/logd_isolate_model/STATUS.md
+++ b/.agents/knowledge/logd_isolate_model/STATUS.md
@@ -1,0 +1,32 @@
+# logd Isolate Model — Status
+> Current as of: v0.9.4 | Created: 2026-08-19
+
+---
+
+## Maturity Assessment
+**Current State**: *Deployment-level convenience; semantic model is primary-isolate-centric.*
+
+The current multi-isolate capabilities (`AsyncHandler`, `.async()` target handler factories, `NativeIsolateSink`) successfully offload heavy serialization, formatting, and physical I/O to background isolates. However, the core semantic model (`Logger` hierarchy, configuration registry, ambient context, filter trees) remains local to each isolate's heap.
+
+---
+
+## Capability Breakdown
+
+| Component / Layer | State | Details |
+|---|---|---|
+| `AsyncHandler` / `IsolateWorker` | ✅ Stable | Reusable background worker isolate lifecycle, message queue, error restart. |
+| `NativeIsolateSink` | ✅ Stable | Auto-respawn on worker crash (2s backoff), startup pre-ready packet buffering. |
+| `LoggerSerializationRegistry` | ⚠️ Point Patch | Static snapshot serialization of `LoggerConfig` across isolates via `exportConfig()` / `importConfig()`. |
+| `LogBrightness` Serialization | ✅ Stable | Theme brightness state correctly preserved across isolate boundaries. |
+| `LogContext` Zone Propagation | ❌ Local Only | Dart `Zone`s do not cross isolate boundaries. Ambient context must be explicitly copied into `SendPort` payloads. |
+| Configuration Authority | ❌ Undefined | Primary isolate owns config by convention only. Worker isolate mutations silently diverge. |
+| Dynamic Config Synchronization | ❌ Immature / Deferred | Point-patch `LogdIsolateHub` rejected in favor of formal multi-isolate system design. |
+| Cross-Isolate Trace Correlation | ❌ Missing | No native trace ID / span ID propagation protocol across isolate message ports. |
+| Unified Entry Pipeline | ❌ Undefined | Worker isolates either maintain independent logging pipelines or stream raw serialized packets to primary sink. |
+
+---
+
+## Active Roadmap Position
+- **Status**: Research & Design Phase for **v0.10.x track** (formal multi-isolate architecture).
+- **Decision**: Reject point-patch synchronization bus (`LogdIsolateHub`) in v0.9.x to avoid layering patches on top of an unprincipled isolate model. Use `v0.10.x` series to iterate on the multi-isolate model before committing to `v1.0.0` API stability.
+- **Reference**: See [ARCHITECTURE.md](file:///home/ono/Projects/logd/.agents/knowledge/logd_isolate_model/ARCHITECTURE.md) and [OPEN_QUESTIONS.md](file:///home/ono/Projects/logd/.agents/knowledge/logd_isolate_model/OPEN_QUESTIONS.md).

--- a/.agents/knowledge/logd_output_design/SESSIONS.md
+++ b/.agents/knowledge/logd_output_design/SESSIONS.md
@@ -4,6 +4,34 @@
 
 ---
 
+## 2026-08-05 | v0.9.3 | Target Handlers & ADR-006 Resolution
+
+### What We Did
+- Standardized 8 pre-wired `{Target}Handler` convenience subclasses (`ConsoleHandler`, `HtmlFileHandler`, `JsonFileHandler`, `PlainFileHandler`, `ToonFileHandler`, `MarkdownFileHandler`, `HttpDashboardHandler`, `MemoryHandler`).
+- Added `.async()` background isolate constructors across all output-bound handlers (~15 µs return).
+- Standardized the `{Target}Handler` convention across core and satellite ecosystem (`logd_sqlite`, `logd_sentry`).
+
+---
+
+## 2026-07-28 | v0.9.1 | TOON Format, AutoEncoder Protocol & Self-Declaring Wrapping
+
+### What We Did
+- Introduced native `ToonFormatter` and `ToonEncoder` for token-efficient LLM logging and telemetry streams.
+- Added `AutoEncoder` protocol contract (`'logd.encoder'`), allowing sinks to automatically detect the matching physical encoder from `document.metadata`.
+- Added `requiredStrategy` to `LogEncoder`, allowing `EncodingSink` to self-default to `WrappingStrategy.document` for `HtmlEncoder` without manual user configuration.
+- Added bounded `MemorySink<T>` ring buffer.
+
+---
+
+## 2026-07-22 | v0.9.0 | Theming Unification & HtmlStylesheet Extraction
+
+### What We Did
+- Resolved theme ownership: `StyleDecorator` is now the single source of truth for semantic tag-to-style resolution and attaches `document.metadata['logd.theme']`.
+- Decoupled CSS/JS generation from `HtmlEncoder` into `HtmlStylesheet` and `DefaultHtmlStylesheet`.
+- Added `LogBrightness` (`dark`, `light`), `lightScheme`, and theme presets (`DarkTheme`, `LightTheme`, `PastelTheme`, `HighContrastTheme`).
+
+---
+
 ## 2026-07-08 | v0.8.7 | Session d882b493
 
 ### What We Did

--- a/.agents/knowledge/logd_output_design/STATUS.md
+++ b/.agents/knowledge/logd_output_design/STATUS.md
@@ -1,5 +1,5 @@
 # logd Output Pipeline — Status
-> Current as of: v0.8.7 | Updated: 2026-07-08
+> Current as of: v0.9.4 | Updated: 2026-08-19
 
 ---
 
@@ -7,61 +7,26 @@
 
 | Component | State |
 |---|---|
-| `AnsiEncoder` | ✅ Stable. Correct design, delegate all color to `LogTheme`. |
-| `HtmlEncoder` | ⚠️ Functional but has design debt. Interactive control panel added in v0.8.7. |
-| `MarkdownEncoder` | 🔲 Unknown — not yet deeply reviewed. |
-| `LogTheme` / `LogColorScheme` | ⚠️ Missing `LogSurface`. Dark/light heuristic is a workaround. |
-| `WrappingStrategy` | ⚠️ Still a manual user tax. Not yet self-declared by encoders. |
-| `StyleDecorator` | ⚠️ One of three theme owners. No single source of truth. |
-| `FileSink` | ⚠️ Lifecycle (dispose) is manual. Silent failure if omitted for HTML. |
-| `LogOutput` facade | ❌ Not yet implemented. Waiting for user validation. |
+| `AnsiEncoder` | ✅ Stable. Pure rendering, delegates all color/styling to `LogTheme`. |
+| `HtmlEncoder` | ✅ Stable. Extracted `HtmlStylesheet`, interactive control panel, copy button. |
+| `MarkdownEncoder` | ✅ Stable. GitHub-flavored markdown rendering for CI/CD artifacts. |
+| `ToonEncoder` | ✅ Stable since v0.9.1. Token-optimized output for LLMs and WebSocket streams. |
+| `LogTheme` / `LogColorScheme` | ✅ Stable since v0.9.0/v0.9.2. `LogBrightness.dark`/`light`, `lightScheme`, preset themes. |
+| `WrappingStrategy` | ✅ Stable since v0.9.1. Encoders self-declare `requiredStrategy`. Sinks auto-default. |
+| `StyleDecorator` | ✅ Stable since v0.9.0. Sole source of truth attaching `document.metadata['logd.theme']`. |
+| `TargetHandler` Subclasses | ✅ Stable since v0.9.3 (ADR-006). Pre-wired subclasses eliminate pipeline friction. |
+| `FileSink` | ✅ Stable. Auto-flush, time/size rotation, dispose lifecycle. |
+| `LogOutput` facade | 🔲 Superseded by `{Target}Handler` convenience subclasses (`ConsoleHandler`, `HtmlFileHandler`, etc.). |
 
 ---
 
-## What Was Just Done (v0.8.7)
+## What Was Done (v0.8.8 – v0.9.4)
 
-- Added interactive control panel (search, level filters, live counters) to `HtmlEncoder`
-- Added copy-to-clipboard per log entry (JS postamble)
-- Added `_lightColorMap` for WCAG-compliant light-mode colors
-- Added `darkMode: bool` field to `HtmlEncoder` as an explicit surface override
-- Fixed `_css()` to use `_isDark` as the single truth (was two parallel heuristics)
-- All HTML showcase examples now delete stale files at startup (append-mode integrity)
-- XSS escaping added for map keys
-- Fixed `TableNode` column fallback when `columnWidths` is empty
-- All HTML goldens regenerated
-
----
-
-## Next Steps (Prioritized)
-
-### 1. `LogSurface` in `LogTheme` ← Unblocks everything downstream
-Additive change. No breaking API impact.
-```dart
-enum LogSurface { dark, light }
-class LogTheme {
-  final LogSurface surface; // new field
-  static const dark  = LogTheme(surface: LogSurface.dark,  ...);
-  static const light = LogTheme(surface: LogSurface.light, ...);
-}
-```
-Once this exists: `HtmlEncoder.darkMode` is deprecated, `_lightColorMap` moves to `LogColorScheme.lightScheme`.
-
-### 2. `lightScheme` in `LogColorScheme`
-The WCAG-AA values are already known (see ARCHITECTURE.md). This is a pure addition.
-
-### 3. Encoder declares `requiredStrategy`
-```dart
-abstract interface class LogEncoder {
-  WrappingStrategy get requiredStrategy => WrappingStrategy.none;
-}
-class HtmlEncoder implements LogEncoder {
-  @override WrappingStrategy get requiredStrategy => WrappingStrategy.document;
-}
-```
-`EncodingSink` reads this automatically. `WrappingStrategy` disappears from public API.
-
-### 4. `LogOutput` facade (deferred — do after steps 1–3)
-Only ship after 2–3 real production use cases validate the API shape. Not yet.
+- **v0.9.3**: Implemented ADR-006 Pre-Wired `{Target}Handler` convenience subclasses (`ConsoleHandler`, `HtmlFileHandler`, `JsonFileHandler`, `PlainFileHandler`, `ToonFileHandler`, `MarkdownFileHandler`, `HttpDashboardHandler`, `MemoryHandler`) and `.async()` isolate factories.
+- **v0.9.2**: Fixed `LogBrightness` theme serialization across isolate boundaries; added high-contrast light mode palettes (`--warning: #92400e;`).
+- **v0.9.1**: Added native `ToonFormatter` / `ToonEncoder`; added `AutoEncoder` protocol auto-detection contract (`'logd.encoder'`); enabled encoders to self-declare `requiredStrategy`.
+- **v0.9.0**: Unified theming with `StyleDecorator` as sole authority; decoupled CSS/JS into `HtmlStylesheet`; added standard theme presets (`DarkTheme`, `LightTheme`, `PastelTheme`, `HighContrastTheme`).
+- **v0.8.8**: Added `HttpServerSink` live dashboard viewer with live WebSocket streaming and raw HTML segment rendering.
 
 ---
 

--- a/.agents/knowledge/logd_product/ROADMAP.md
+++ b/.agents/knowledge/logd_product/ROADMAP.md
@@ -79,20 +79,24 @@ The following is a professional critical analysis of the three-area product road
 ## Unified Phased Roadmap (Revised 2026-07-18)
 
 ```
-Phase 1 (v0.9.x) — API Stabilization
-  - Audit all public symbols: @stable / @experimental / @internal
-  - Define and publish semver contract document
-  - DX quality pass (error messages, self-init, single import)
-  - Freeze Handler, LogSink, LogFormatter extension points
-  - Criticize and Standardize Theming API (light/dark, WCAG compliance) + integrated various outputs themes and color schemes + API DX ovehaul
-  
+Phase 1 (v0.9.x) — Foundation, DX & Performance
+  - Audit public symbols: @stable / @experimental / @internal
+  - Publish semver contract document
+  - TargetHandler convenience subclasses (ADR-006) & dual-mode .async() offloading
+  - Unified theming & HtmlStylesheet extraction
+  - Ambient Structured Context (LogContext.run / MDC) & caller origin bypass
 
-Phase 2 (v1.0) — Major Release & Ecosystem Expansion
-  - No breaking changes vs Phase 1 stable symbols
-  - First-party satellite sinks: logd_sqlite, logd_memory, logd_sentry
+Phase 2 (v0.10.x) — Multi-Isolate Architecture & Ecosystem Expansion
+  - Principled Multi-Isolate Architecture (explicit topology roles, configuration broadcast protocol, ambient context bridging, unified ingestion stream — see `logd_isolate_model/`)
+  - Satellite ecosystem maturation: logd_sqlite, logd_memory, logd_sentry
+  - Validate multi-isolate contracts in real-world server/cluster/worker scenarios
+
+Phase 3 (v1.0.0) — Major Release & API Stability Lock
+  - Public declaration of complete API stability across single and multi-isolate models
+  - Zero breaking changes to @stable symbols without major semver bumps
   - Deprecation notices on HttpServerSink, SocketSink, NativeEngine in core
 
-Phase 3 (v1.1+) — Dependency Extraction & Lean Core
+Phase 4 (v1.1+ / v2.0) — Dependency Extraction & Lean Core
   - logd_http, logd_socket, logd_native published as satellite packages
   - Remove deprecated transitive deps from core
   - Core becomes dependency-minimal (timezone, meta, characters only)
@@ -102,23 +106,29 @@ Phase 3 (v1.1+) — Dependency Extraction & Lean Core
 
 ## Phase Timeline Detail
 
-### Phase 1: API Stabilization (v0.9.x)
-**Goal**: Produce a stable, documented, annotated public API surface that can safely be targeted by satellite packages.
+### Phase 1: Foundation, DX & Performance (v0.9.x)
+**Goal**: Establish clean DX, robust theming, ambient structured logging, and hot-path execution efficiency.
 - Symbol annotation audit (`@stable`, `@experimental`, `@internal` via `package:meta`)
 - Publish semver contract document in `doc/`
-- DX quality pass: self-initialization, unified import, actionable error messages
-- Formal freeze of `LogSink`, `LogFormatter`, `LogDecorator`, `Handler` extension points
-- `LogSurface` / light mode theme consolidation (defer facade until Phase 2)
+- TargetHandler pre-wired subclasses (ADR-006)
+- Ambient Structured Context (`LogContext.run`) & hot-path caller origin bypass (`includeOrigin: false`)
+- Theming unification (`LogBrightness`, `lightScheme`)
 
-### Phase 2: Major Release & Ecosystem Expansion (v1.0)
-**Goal**: Publicly declare API stability and launch the plugin ecosystem.
-- Zero breaking changes relative to Phase 1 `@stable` symbols
-- Launch satellite packages: `logd_sqlite`, `logd_memory`, `logd_sentry`
-- `LogOutput` facade (convenience constructors: `LogOutput.console()`, `LogOutput.htmlFile()`)
-- Deprecation notices on `HttpServerSink`, `SocketSink`, `NativeEngine` in core with migration guides to satellite equivalents
-- Session/Handle lifecycle pattern for atomic sink disposal
+### Phase 2: Multi-Isolate Architecture & Ecosystem Expansion (v0.10.x)
+**Goal**: Design and iterate on a principled multi-isolate semantic model with full design freedom before committing to v1.0 API freeze.
+- Explicit topology roles (`primary`, `worker`)
+- Deterministic binary configuration broadcast protocol
+- Cross-isolate ambient context serialization & restoration bridges
+- Centralized unified ingestion stream vs. distributed pipeline validation
+- Satellite packages launch: `logd_sqlite`, `logd_memory`, `logd_sentry`
 
-### Phase 3: Lean Core (v1.1+)
+### Phase 3: Major Release & API Stability Lock (v1.0.0)
+**Goal**: Publicly declare full API stability across all execution models.
+- Zero breaking changes relative to `@stable` symbols
+- Full semver breaking-change commitment for production consumers
+- Formal deprecation notices for heavy transitive network/FFI dependencies in core
+
+### Phase 4: Lean Core (v1.1+ / v2.0)
 **Goal**: Reduce core to a minimal, fast, dependency-light foundation.
 - Publish `logd_http` (HttpServerSink + WebSocket dashboard)
 - Publish `logd_socket` (SocketSink, network reconnect)

--- a/.agents/knowledge/logd_product/SESSIONS.md
+++ b/.agents/knowledge/logd_product/SESSIONS.md
@@ -4,6 +4,65 @@
 
 ---
 
+## 2026-08-19 | v0.9.4 | Hot-Path Origin Bypass & Ambient Structured Context (MDC)
+
+- **Focus**: Performance optimization and Mapped Diagnostic Context (MDC).
+- **Key Deliverables**:
+  - `includeOrigin: false` config option bypassing `StackTrace.current` VM unwinding for ~5x throughput speedup.
+  - `LogContext.run()` Zone-based ambient structured context propagation across async boundaries.
+  - Zero-allocation merge semantics (`LogContext.merge()`) on baseline logging paths.
+  - Full formatter integration across `StructuredFormatter`, `PlainFormatter`, `JsonFormatter`, and `ToonFormatter`.
+- **Strategic Architecture Decision**:
+  - Audited multi-isolate behavior following `LogContext` Zone-scoping.
+  - Rejected point-patch cross-isolate pub/sub bus (`LogdIsolateHub`) in favor of a comprehensive, principled multi-isolate architecture for the **v0.10.x milestone track** before locking the API for `v1.0.0`.
+  - Established dedicated knowledge item `.agents/knowledge/logd_isolate_model/` covering topology roles, configuration authority, ambient context bridging, and unified log ingestion.
+- **PR**: #60 merged to `dev`; #61 open on `dev`.
+
+---
+
+## 2026-08-05 | v0.9.3 | Target Handlers & Dual-Mode `.async()` Offloading
+
+- **Focus**: Beginner developer experience (DX) and pipeline wiring simplification.
+- **Key Deliverables**:
+  - Authored and adopted **ADR-006**: Pre-Wired `{Target}Handler` Convenience Subclass Architecture.
+  - Introduced 8 zero-config target handler subclasses (`ConsoleHandler`, `HtmlFileHandler`, `JsonFileHandler`, `PlainFileHandler`, `ToonFileHandler`, `MarkdownFileHandler`, `HttpDashboardHandler`, `MemoryHandler`).
+  - Added `.async()` factory constructors across all output-bound handlers for non-blocking isolate offloading (~15 µs return).
+  - Created `package:logd/advanced.dart` entry point for custom engine developers.
+
+---
+
+## 2026-08-01 | v0.9.2 | Theme Isolate State Preservation & SQLite Satellite Package
+
+- **Focus**: Multi-isolate state synchronization and satellite ecosystem launch.
+- **Key Deliverables**:
+  - Preserved `LogBrightness` across isolate transfers in `LoggerSerializationRegistry`.
+  - Launched `logd_sqlite` (v0.1.0) with WAL persistence, prepared statement caching, and retention pruning.
+  - Added high-contrast WCAG AA light mode palettes.
+
+---
+
+## 2026-07-28 | v0.9.1 | Native TOON Logging & AutoEncoder Protocol Detection
+
+- **Focus**: Token-optimized LLM formatting and sink self-configuration.
+- **Key Deliverables**:
+  - Native `ToonFormatter` / `ToonEncoder` implementation and `doc/toon_spec.md` specification.
+  - Protocol auto-detection via `AutoEncoder` and `'logd.encoder'` metadata contract.
+  - Self-declaring `requiredStrategy` on encoders.
+  - `MemorySink<T>` in-memory ring-buffer with capacity caps.
+
+---
+
+## 2026-07-22 | v0.9.0 | API Stabilization & Semver Contract (Phase 1 Milestone)
+
+- **Focus**: Public symbol audit, semver breaking-change guarantees, and theme unification.
+- **Key Deliverables**:
+  - Audited and decorated public symbols (`@experimental` on low-level FFI/isolate engines).
+  - Published `doc/semver_contract.md`.
+  - Unified theme ownership under `StyleDecorator` and `document.metadata['logd.theme']`.
+  - Extracted `HtmlStylesheet` from `HtmlEncoder`.
+
+---
+
 ## 2026-07-18 | v0.8.9 | Hardening, Web Source Mapping & Roadmap Pivot
 
 - **Focus**: Phase A Hardening completion — polymorphic serialization fix, timezone input hardening and benchmarks, concurrency stress tests, Web Source Mapping, formal ADR documentation.

--- a/.agents/knowledge/logd_product/STATUS.md
+++ b/.agents/knowledge/logd_product/STATUS.md
@@ -1,13 +1,11 @@
 # logd Product — Status
-> Current as of: v0.8.9 | Updated: 2026-07-18
+> Current as of: v0.9.4 | Updated: 2026-08-19
 
 ---
 
 ## Active Product Focus
 
-v0.8.9 is released (PR #52 open → master). Both `logd` v0.8.9 and `logd_linters` v0.1.2 are published to pub.dev.
-
-The roadmap has been strategically revised. The next active phase is **Phase 1 (API Stabilization)** targeting the v0.9.x release series.
+v0.9.4 active development. Stack Trace Origin Bypass and Ambient Structured Context (MDC / `LogContext`) are implemented, validated, and documented.
 
 ---
 
@@ -19,19 +17,20 @@ The roadmap has been strategically revised. The next active phase is **Phase 1 (
 | **v0.8.8 (Async / HTTP)** | AsyncHandler isolate offloading, HttpServerSink dashboard, HTML concurrency | ✅ Released |
 | **v0.8.9 (Hardening)** | Web Source Mapping, polymorphic serialization fix, timezone hardening, ADRs | ✅ Released |
 | **v0.1.2 (logd_linters)** | Automated quick-fixes for arena lifecycle, purity, and formatting rules | ✅ Published |
-| **Phase 1 (API Stabilization / v0.9.0)** | Symbol annotation audit, semver contract, DX pass, extension point freeze | ✅ Released |
-| **Phase 2 (v1.0 + Ecosystem)** | logd_sqlite, logd_memory, logd_sentry, LogOutput facade, deprecation notices | 🔲 Next |
-| **Phase 3 (Lean Core)** | logd_http, logd_socket, logd_native split out, core dependency reduction | 🔲 Planned |
+| **v0.9.0–v0.9.2 (API Hardening)** | Symbol audit, semver contract, logd_sqlite satellite package launch | ✅ Released |
+| **v0.9.3 (Target Handlers)** | Pre-wired TargetHandler subclasses, dual-mode `.async()`, `advanced.dart` | ✅ Released |
+| **v0.9.4 (MDC & Performance)** | Hot-path caller origin bypass, ambient structured context (`LogContext.run`) | 🟡 In Progress (PR #61) |
+| **v0.10.0 (Multi-Isolate Architecture)** | Principled isolate topology, config authority, context bridging, satellite ecosystem | 🔲 Next |
+| **v1.0.0 (API Freeze & Stability)** | Full stability declaration, breaking-change policy lock, deprecation guides | 🔲 Future |
 
 ---
 
 ## Current Core Package State
 
-- **Version**: `0.8.9`
+- **Version**: `0.9.4`
 - **Dart SDK**: `>=3.6.0 <4.0.0`
 - **Direct Dependencies**: `characters`, `ffi`, `http`, `matcher`, `meta`, `timezone`, `source_maps`, `source_span`, `web_socket_channel`
-- **Dependencies to Extract in Phase 3**: `ffi`, `http`, `web_socket_channel`
-- **Tests**: All 2,439 unit and integration tests passing.
+- **Tests**: All 2,513 unit and integration tests passing.
 - **Lints**: Zero analyzer warnings across all packages.
 
 ---

--- a/doc/stack_trace/architecture.md
+++ b/doc/stack_trace/architecture.md
@@ -318,25 +318,38 @@ Format: `#0 a.b (file.dart:10:5)`
 
 ## Integration with Logger Module
 
-The logger module uses `StackTraceParser.parse()` for single-pass extraction of both caller and stack frames:
+The logger module uses `StackTraceParser.parse()` for single-pass extraction of both caller and stack frames, while supporting complete VM stack trace bypass when origin extraction is disabled:
 
-**Location**: `Logger._log()` in logger module
+**Location**: `Logger.logInternal` in logger module
 
 ```dart
-final frameCount = stackMethodCount[level] ?? 0;
-final parsed = stackTraceParser.parse(
-  stackTrace: stackTrace ?? StackTrace.current,
-  skipFrames: 1,  // Skip Logger._log itself
-  maxFrames: frameCount,
-);
-if (parsed.caller == null) return;
+final needsCaller = resolved.includeOrigin;
+final frameCount = resolved.stackMethodCount[level] ?? 0;
+final needsFrames = frameCount > 0;
+final needsParse = needsCaller || needsFrames || stackTrace != null;
 
-final entry = LogEntry(
-  origin: _buildOrigin(parsed.caller!),
-  stackFrames: parsed.frames.isEmpty ? null : parsed.frames,
-  // ...
-);
+String origin = '';
+List<CallbackInfo>? stackFrames;
+
+if (needsParse) {
+  final rawTrace = stackTrace ?? StackTrace.current;
+  final parsed = resolved.stackTraceParser.parse(
+    stackTrace: rawTrace,
+    skipFrames: 1, // Skip Logger.logInternal itself
+    maxFrames: frameCount,
+  );
+  if (needsCaller && parsed.caller != null) {
+    origin = _buildOrigin(
+      parsed.caller!,
+      resolved.includeFileLineInHeader,
+    );
+  }
+  stackFrames = (needsFrames && parsed.frames.isNotEmpty) ? parsed.frames : null;
+}
 ```
+
+### Hot-Path Origin Bypass (v0.9.4+)
+When `includeOrigin: false` and `stackMethodCount[level] == 0` without an explicit `stackTrace`, `needsParse` is `false`. In this mode, `StackTrace.current` VM allocation and `StackTraceParser.parse` regex evaluation are completely bypassed, delivering up to a **~5x throughput speedup** on hot logging loops.
 
 ## Equality and Hashing
 


### PR DESCRIPTION
## Summary
- Backfills missing session logs and statuses across releases v0.8.8 through v0.9.4 in `.agents/knowledge/` (core, output design, product).
- Completes documentation for hot-path caller origin bypass in `doc/stack_trace/architecture.md`.
- Establishes dedicated knowledge item `.agents/knowledge/logd_isolate_model/` for multi-isolate architecture analysis.
- Calibrates product roadmap to establish **Phase 2 (v0.10.x)** as the dedicated multi-isolate architecture track ahead of **Phase 3 (v1.0.0)** stability freeze.